### PR TITLE
feat(jwt): Add jwt for user authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,12 @@ dependencies {
     implementation 'com.google.code.gson:gson'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.projectlombok:lombok:1.18.20'
+    implementation 'org.projectlombok:lombok:1.18.20'
 
     compileOnly 'org.projectlombok:lombok'
-
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,8 @@ dependencies {
     implementation 'com.google.code.gson:gson'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.projectlombok:lombok:1.18.20'
-    implementation 'org.projectlombok:lombok:1.18.20'
 
     compileOnly 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
@@ -1,0 +1,30 @@
+package com.swyp3.babpool.domain.user.api;
+
+import com.swyp3.babpool.global.util.jwt.application.JwtServiceImpl;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+public class UserSignOutApi {
+
+    private final JwtServiceImpl jwtService;
+
+    @PostMapping("/api/user/sign/out")
+    public void signOut(HttpServletRequest request){
+        Cookie[] cookies = request.getCookies();
+        if(cookies != null){
+            Optional<Cookie> optionalCookie = Arrays.stream(cookies)
+                    .filter(cookie -> cookie.getName().equals("userRefreshToken"))
+                    .findAny();
+            optionalCookie.ifPresent(cookie -> jwtService.logout(cookie.getValue()));
+        }
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
@@ -1,0 +1,26 @@
+package com.swyp3.babpool.global.config;
+
+import com.swyp3.babpool.global.util.jwt.JwtTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcInterceptJwtConfig implements WebMvcConfigurer {
+
+    private final JwtTokenInterceptor jwtTokenInterceptor;
+    private static final String[] EXCLUDE_PATHS = {
+        "/api/user/sign/in", "/api/user/sign/up", "/api/user/sign/out", "/api/user/sign/refresh",
+        "/api/test/connection", "/api/test/jwt/permitted",
+        "/api/profile/list"
+    };
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtTokenInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns(EXCLUDE_PATHS);
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/JwtAuthenticator.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/JwtAuthenticator.java
@@ -1,0 +1,27 @@
+package com.swyp3.babpool.global.util.jwt;
+
+import com.swyp3.babpool.global.uuid.dao.UserUuidRepository;
+import com.swyp3.babpool.global.uuid.exception.UuidErrorCode;
+import com.swyp3.babpool.global.uuid.exception.UuidException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticator {
+
+    private final JwtTokenizer jwtTokenizer;
+    private final UserUuidRepository userUuidRepository;
+
+    public Claims authenticate(String accessToken) {
+        return jwtTokenizer.parseAccessToken(accessToken);
+    }
+
+    public Long jwtTokenUserIdResolver(String userUuid) {
+        return userUuidRepository.findByUserUuId(userUuid).orElseThrow(
+                    () -> new UuidException(UuidErrorCode.NOT_FOUND_USER_UUID,
+                            "Not found user id with uuid, while JwtAuthenticator request to UserUuidRepository"))
+                .getUserId();
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/JwtTokenInterceptor.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/JwtTokenInterceptor.java
@@ -1,0 +1,79 @@
+package com.swyp3.babpool.global.util.jwt;
+
+import com.swyp3.babpool.global.util.jwt.exception.BadCredentialsException;
+import com.swyp3.babpool.global.util.jwt.exception.errorcode.JwtExceptionErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.security.WeakKeyException;
+import io.netty.util.internal.StringUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtAuthenticator jwtAuthenticator;
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException, IOException {
+        String accessToken = StringUtil.EMPTY_STRING;
+        Claims authenticatedClaims = null;
+        try {
+            accessToken = getAccessTokenFrom(request);
+            if (StringUtils.hasText(accessToken)) {
+                authenticatedClaims = jwtAuthenticator.authenticate(accessToken);
+            }
+            if (!authenticatedClaims.isEmpty()){
+                Long userId = jwtAuthenticator.jwtTokenUserIdResolver(authenticatedClaims.getSubject());
+                request.setAttribute("userId", userId);
+            }
+        } catch (NullPointerException | IllegalStateException e) {
+            log.error("Not found Token // token : {}", accessToken);
+            throw new BadCredentialsException(JwtExceptionErrorCode.NOT_FOUND_TOKEN, "throw new not found token exception");
+        } catch (SecurityException | MalformedJwtException | SignatureException | WeakKeyException e) {
+            log.error("Invalid Token // token : {}", accessToken);
+            throw new BadCredentialsException(JwtExceptionErrorCode.INVALID_TOKEN, "throw new invalid token exception");
+        } catch (ExpiredJwtException e) {
+            log.error("EXPIRED Token // token : {}", accessToken);
+            throw new BadCredentialsException(JwtExceptionErrorCode.EXPIRED_TOKEN, "throw new expired token exception");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported Token // token : {}", accessToken);
+            throw new BadCredentialsException(JwtExceptionErrorCode.UNSUPPORTED_TOKEN, "throw new unsupported token exception");
+        } catch (Exception e) {
+            log.error("====================================================");
+            log.error("Babpool JwtTokenInterceptor - preHandle() 오류 발생");
+            log.error("token : {}", accessToken);
+            log.error("Exception Message : {}", e.getMessage());
+            log.error("Exception StackTrace : {");
+            e.printStackTrace();
+            log.error("}");
+            log.error("====================================================");
+            throw new BadCredentialsException(JwtExceptionErrorCode.NOT_FOUND_TOKEN, "throw new exception");
+        }
+        return true;
+    }
+
+
+    private String getAccessTokenFrom(HttpServletRequest request) {
+        String authorization = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(authorization) && authorization.startsWith(BEARER)) {
+            return authorization.split(" ")[1];
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/application/JwtService.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/application/JwtService.java
@@ -1,0 +1,14 @@
+package com.swyp3.babpool.global.util.jwt.application;
+
+import com.swyp3.babpool.global.util.jwt.application.response.JwtPairDto;
+
+import java.util.List;
+
+public interface JwtService {
+
+    JwtPairDto createJwtPair(String userUUID, List roles);
+
+    String extendLoginState(String refreshToken);
+
+    void logout(String refreshToken);
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/application/JwtServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/application/JwtServiceImpl.java
@@ -1,0 +1,65 @@
+package com.swyp3.babpool.global.util.jwt.application;
+
+import com.swyp3.babpool.global.util.jwt.JwtTokenizer;
+import com.swyp3.babpool.global.util.jwt.application.response.JwtPairDto;
+import com.swyp3.babpool.global.util.jwt.exception.BabpoolJwtException;
+import com.swyp3.babpool.global.util.jwt.exception.errorcode.JwtExceptionErrorCode;
+import com.swyp3.babpool.infra.redis.dao.TokenRedisRepository;
+import com.swyp3.babpool.infra.redis.domain.TokenForRedis;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService{
+
+    private final TokenRedisRepository tokenRepository;
+    private final JwtTokenizer jwtTokenizer;
+
+    @Value("${property.jwt.refreshTokenExpireDays}")
+    private Integer refreshExpire;
+
+    @Override
+    public JwtPairDto createJwtPair(String userUUID, List roles) {
+        JwtPairDto jwtPairDto = JwtPairDto.builder()
+                .accessToken(jwtTokenizer.createAccessToken(userUUID, roles))
+                .refreshToken(jwtTokenizer.createRefreshToken(userUUID, roles))
+                .build();
+        tokenRepository.save(TokenForRedis.builder()
+                .refreshToken(jwtPairDto.getRefreshToken())
+                .refreshExpire(refreshExpire)
+                .userUUID(userUUID)
+                .build());
+        return jwtPairDto;
+    }
+
+    @Override
+    public String extendLoginState(String refreshToken) {
+        TokenForRedis tokenObject = tokenRepository.findById(refreshToken)
+                .orElseThrow(() -> new BabpoolJwtException(JwtExceptionErrorCode.REFRESH_TOKEN_NOT_FOUND,
+                        "refresh token not found in redis, while extending login state."));
+
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
+        String userUUID = claims.getSubject();
+
+        // TODO : Redis 에서 꺼낸 tokenObject 의 userUUID 와 request refresh token claims 의 userUUID 가 다른지 까지 검증해야 할까요?
+        if (!tokenObject.getUserUUID().equals(userUUID)) {
+            throw new BabpoolJwtException(JwtExceptionErrorCode.REFRESH_TOKEN_NOT_SAME_USER,
+                    "user uuid in request refresh token and redis refresh token are not same, while extending login state.");
+        }
+
+        return jwtTokenizer.createAccessToken(userUUID, claims.get("roles", List.class));
+    }
+
+    @Override
+    public void logout(String refreshTokenFromCookie) {
+        tokenRepository.findById(refreshTokenFromCookie)
+                .orElseThrow(() -> new BabpoolJwtException(JwtExceptionErrorCode.REFRESH_TOKEN_NOT_FOUND,
+                "refresh token not found in redis, while logout"));
+        tokenRepository.deleteById(refreshTokenFromCookie);
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/application/response/JwtPairDto.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/application/response/JwtPairDto.java
@@ -1,0 +1,24 @@
+package com.swyp3.babpool.global.util.jwt.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class JwtPairDto {
+
+    /**
+     * @apiNote
+     * accessToken : 사용자의 인증을 확인하는데 사용되는 토큰으로, 클라이언트의 Local Storage 에 저장한다.
+     * refreshToken : accessToken의 만료시간이 지나면 사용자의 인증을 연장하는데 사용되는 토큰으로, httpsOnly 속성을 가진 쿠키에 저장한다.
+     */
+    public String accessToken;
+    public String refreshToken;
+
+    @Builder
+    public JwtPairDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/BabpoolJwtException.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/BabpoolJwtException.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.global.util.jwt.exception;
+
+import com.swyp3.babpool.global.util.jwt.exception.errorcode.JwtExceptionErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BabpoolJwtException extends RuntimeException{
+
+    private final JwtExceptionErrorCode jwtExceptionErrorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/BadCredentialsException.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/BadCredentialsException.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.global.util.jwt.exception;
+
+import com.swyp3.babpool.global.util.jwt.exception.errorcode.JwtExceptionErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BadCredentialsException extends RuntimeException{
+
+    private final JwtExceptionErrorCode jwtExceptionErrorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/errorcode/JwtExceptionErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/errorcode/JwtExceptionErrorCode.java
@@ -1,0 +1,17 @@
+package com.swyp3.babpool.global.util.jwt.exception.errorcode;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtExceptionErrorCode implements CustomErrorCode {
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "refresh token not found"),
+    REFRESH_TOKEN_NOT_SAME_USER(HttpStatus.UNAUTHORIZED, "refresh token not same user");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/errorcode/JwtExceptionErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/errorcode/JwtExceptionErrorCode.java
@@ -10,7 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum JwtExceptionErrorCode implements CustomErrorCode {
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "refresh token not found"),
-    REFRESH_TOKEN_NOT_SAME_USER(HttpStatus.UNAUTHORIZED, "refresh token not same user");
+    REFRESH_TOKEN_NOT_SAME_USER(HttpStatus.UNAUTHORIZED, "refresh token not same user"),
+
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러"),
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "Headers에서 토큰 형식의 값을 찾을 수 없음"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "기간이 만료된 토큰"),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/handler/JwtExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/handler/JwtExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.swyp3.babpool.global.util.jwt.exception.handler;
+
+import com.swyp3.babpool.global.common.response.ApiErrorResponse;
+import com.swyp3.babpool.global.util.jwt.exception.BabpoolJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class JwtExceptionHandler {
+
+    @ExceptionHandler
+    protected ApiErrorResponse handleBabpoolJwtException(BabpoolJwtException exception){
+        log.error("JwtException getJwtExceptionErrorCode() >> "+exception.getJwtExceptionErrorCode());
+        log.error("JwtException getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getJwtExceptionErrorCode());
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/util/jwt/exception/handler/JwtExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/global/util/jwt/exception/handler/JwtExceptionHandler.java
@@ -2,6 +2,7 @@ package com.swyp3.babpool.global.util.jwt.exception.handler;
 
 import com.swyp3.babpool.global.common.response.ApiErrorResponse;
 import com.swyp3.babpool.global.util.jwt.exception.BabpoolJwtException;
+import com.swyp3.babpool.global.util.jwt.exception.BadCredentialsException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +15,13 @@ public class JwtExceptionHandler {
     protected ApiErrorResponse handleBabpoolJwtException(BabpoolJwtException exception){
         log.error("JwtException getJwtExceptionErrorCode() >> "+exception.getJwtExceptionErrorCode());
         log.error("JwtException getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getJwtExceptionErrorCode());
+    }
+
+    @ExceptionHandler
+    protected ApiErrorResponse handleJwtBadCredentialsException(BadCredentialsException exception){
+        log.error("BadCredentialsException getJwtExceptionErrorCode() >> "+exception.getJwtExceptionErrorCode());
+        log.error("BadCredentialsException getMessage() >> "+exception.getMessage());
         return ApiErrorResponse.of(exception.getJwtExceptionErrorCode());
     }
 }

--- a/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
@@ -1,0 +1,12 @@
+package com.swyp3.babpool.global.uuid.dao;
+
+import com.swyp3.babpool.global.uuid.domain.UserUuid;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface UserUuidRepository {
+
+    Optional<UserUuid> findByUserUuId(String uuid);
+}

--- a/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 @Mapper
 public interface UserUuidRepository {
 
-    Optional<UserUuid> findByUserUuId(String uuid);
+    Optional<UserUuid> findByUserUuId(String userUuid);
 }

--- a/src/main/java/com/swyp3/babpool/global/uuid/domain/UserUuid.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/domain/UserUuid.java
@@ -1,0 +1,19 @@
+package com.swyp3.babpool.global.uuid.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class UserUuid {
+
+    private Long UserId;
+    private String UserUuid;
+
+    @Builder
+    public UserUuid(Long UserId, String UserUuid) {
+        this.UserId = UserId;
+        this.UserUuid = UserUuid;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidErrorCode.java
@@ -1,0 +1,16 @@
+package com.swyp3.babpool.global.uuid.exception;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UuidErrorCode implements CustomErrorCode {
+    NOT_FOUND_USER_UUID(HttpStatus.NOT_FOUND, "Not found user uuid."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidException.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidException.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.global.uuid.exception;
+
+import com.swyp3.babpool.global.util.jwt.exception.errorcode.JwtExceptionErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UuidException extends RuntimeException{
+
+    private final UuidErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/exception/UuidExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.swyp3.babpool.global.uuid.exception;
+
+import com.swyp3.babpool.global.common.response.ApiErrorResponse;
+import com.swyp3.babpool.global.util.jwt.exception.BabpoolJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class UuidExceptionHandler {
+
+    @ExceptionHandler
+    protected ApiErrorResponse handleUuidException(UuidException exception){
+        log.error("UuidException getUuidErrorCode() >> "+exception.getErrorCode());
+        log.error("UuidException getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getErrorCode());
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
+++ b/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
@@ -2,10 +2,13 @@ package com.swyp3.babpool.infra.health.api;
 
 import com.swyp3.babpool.infra.health.application.HealthCheckService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class HealthCheckApi {
@@ -15,5 +18,16 @@ public class HealthCheckApi {
     @GetMapping("/api/test/connection")
     public ResponseEntity<Integer> testConnection() {
         return ResponseEntity.ok(healthCheckService.testConnection());
+    }
+
+    @GetMapping("/api/test/jwt/require")
+    public ResponseEntity<String> testJwtRequire(@RequestHeader("userId") Long userId) {
+        log.info("userId from request header : {}", userId);
+        return ResponseEntity.ok("success");
+    }
+
+    @GetMapping("/api/test/jwt/permitted")
+    public ResponseEntity<String> testJwtPermitted() {
+        return ResponseEntity.ok("success");
     }
 }

--- a/src/main/java/com/swyp3/babpool/infra/redis/domain/TokenForRedis.java
+++ b/src/main/java/com/swyp3/babpool/infra/redis/domain/TokenForRedis.java
@@ -15,9 +15,9 @@ import java.util.concurrent.TimeUnit;
 public class TokenForRedis {
 
     @Id
-    String userUUID;
-
     String refreshToken;
+
+    String userUUID;
 
     @TimeToLive(unit = TimeUnit.DAYS)
     Integer refreshExpire;

--- a/src/main/java/com/swyp3/babpool/infra/redis/domain/TokenForRedis.java
+++ b/src/main/java/com/swyp3/babpool/infra/redis/domain/TokenForRedis.java
@@ -2,12 +2,14 @@ package com.swyp3.babpool.infra.redis.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
 import java.util.concurrent.TimeUnit;
 
+@ToString
 @Getter
 @RedisHash("token")
 public class TokenForRedis {

--- a/src/main/resources/mapper/UserUuidMapper.xml
+++ b/src/main/resources/mapper/UserUuidMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.global.uuid.dao.UserUuidRepository">
+
+    <resultMap id="userUuid" type="com.swyp3.babpool.global.uuid.domain.UserUuid">
+        <id property="userId" column="user_id"/>
+        <result property="userUuid" column="user_uuid"/>
+    </resultMap>
+
+    <select id="findByUserUuId" parameterType="Long" resultMap="userUuid">
+        SELECT * FROM t_user_uuid where user_uuid = #{userUuid}
+    </select>
+
+
+</mapper>

--- a/src/main/resources/mapper/UserUuidMapper.xml
+++ b/src/main/resources/mapper/UserUuidMapper.xml
@@ -8,7 +8,7 @@
         <result property="userUuid" column="user_uuid"/>
     </resultMap>
 
-    <select id="findByUserUuId" parameterType="Long" resultMap="userUuid">
+    <select id="findByUserUuId" resultMap="userUuid">
         SELECT * FROM t_user_uuid where user_uuid = #{userUuid}
     </select>
 

--- a/src/test/java/com/swyp3/babpool/global/util/jwt/JwtAuthenticatorTest.java
+++ b/src/test/java/com/swyp3/babpool/global/util/jwt/JwtAuthenticatorTest.java
@@ -1,0 +1,118 @@
+package com.swyp3.babpool.global.util.jwt;
+
+import com.swyp3.babpool.global.uuid.dao.UserUuidRepository;
+import com.swyp3.babpool.global.uuid.exception.UuidException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.InvalidKeyException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@MybatisTest
+class JwtAuthenticatorTest {
+
+    private JwtAuthenticator jwtAuthenticator;
+    private JwtTokenizer jwtTokenizer;
+    @Autowired
+    UserUuidRepository userUuidRepository;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenizer = new JwtTokenizer("12345678901234567890123456789012", "12345678901234567890123456789012");
+        jwtAuthenticator = new JwtAuthenticator(jwtTokenizer, userUuidRepository);
+    }
+
+    @DisplayName("토큰을 파싱해 클레임을 반환한다. 올바른 토큰인 경우")
+    @Test
+    void authenticate_proper_access_token() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6266";
+        List<String> roles = List.of("ROLE_USER");
+        String accessToken = jwtTokenizer.createAccessToken(userUUID, roles);
+        log.info("accessToken: {}", accessToken);
+        // when
+        Claims claims = jwtAuthenticator.authenticate(accessToken);
+        log.info("claims.getSubject(): {}", claims.getSubject());
+        // then
+        assertThat(claims).isNotEmpty();
+        assertThat(claims.getSubject()).isEqualTo(userUUID);
+    }
+
+    @DisplayName("토큰을 파싱해 클레임을 반환한다. 올바르지 않은 토큰인 경우")
+    @Test
+    void authenticate_improper_access_token() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6266";
+        List<String> roles = List.of("ROLE_USER");
+        String accessToken = jwtTokenizer.createAccessToken(userUUID, roles);
+        // when
+        // then
+        assertThrows(SignatureException.class, () -> {
+            jwtAuthenticator.authenticate(accessToken + "a");
+        });
+    }
+
+    @DisplayName("토큰을 파싱해 클레임을 반환한다. 만료된 토큰인 경우")
+    @Test
+    void authenticate_expired_access_token() {
+        // given
+        String accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0NjcwN2Q5Mi0wMmY0LTQ4MTctODExNi1hNGMzYjIzZTYyNjYiLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNzA4OTA5NDQ4LCJleHAiOjF9.YX_hZKjbewwz1FFaj6aOLPogUs1jPK5UC1aR1dHbB7A";
+        // when
+        // then
+        assertThrows(ExpiredJwtException.class, () -> {
+            jwtAuthenticator.authenticate(accessToken);
+        });
+    }
+
+    @DisplayName("토큰을 파싱해 클레임을 반환한다. 토큰이 빈 문자열인 경우")
+    @Test
+    void authenticate_empty_access_token() {
+        // given
+        String accessToken = "";
+        // when
+        // then
+        assertThrows(IllegalArgumentException.class, () -> {
+            jwtAuthenticator.authenticate(accessToken);
+        });
+    }
+
+    @DisplayName("토큰을 파싱해 클레임을 반환한다. 지원하지 않는 알고리즘의 토큰인 경우")
+    @Test
+    void authenticate_unsupported_access_token() {
+        // given
+        String accessToken = "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI0NjcwN2Q5Mi0wMmY0LTQ4MTctODExNi1hNGMzYjIzZTYyNjYiLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNzA4OTA5NDQ4LCJleHAiOjF9.MroKm4-jOBCvpVZayg2duSri8ZdLSc5au1N3Mhpgbr0Q_B_3D088pk1rCDkOKDfr";
+        // when
+        // then
+        assertThrows(InvalidKeyException.class, () -> {
+            jwtAuthenticator.authenticate(accessToken);
+        });
+    }
+
+    @DisplayName("userUuid 으로 UserUuidRepository 에서 userId를 조회한다. 존재하지 않는 경우 예외가 발생한다.")
+    @Test
+    void findUserIdByUserUuid_not_exist() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6266";
+        // when
+        // then
+        assertThrows(UuidException.class, () -> {
+            jwtAuthenticator.jwtTokenUserIdResolver(userUUID);
+        });
+    }
+}

--- a/src/test/java/com/swyp3/babpool/global/util/jwt/JwtTokenizerTest.java
+++ b/src/test/java/com/swyp3/babpool/global/util/jwt/JwtTokenizerTest.java
@@ -1,0 +1,88 @@
+package com.swyp3.babpool.global.util.jwt;
+
+
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+class JwtTokenizerTest {
+
+    JwtTokenizer jwtTokenizer;
+
+    @BeforeEach
+    void setUp(){
+        jwtTokenizer = new JwtTokenizer("12345678901234567890123456789012", "12345678901234567890123456789012");
+    }
+
+    @DisplayName("UUID와 Role 정보를 이용하여 AccessToken 생성한다.")
+    @Test
+    void createAccessToken() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6266";
+        List<String> roles = List.of("ROLE_USER");
+        // when
+        String accessToken = jwtTokenizer.createAccessToken(userUUID, roles);
+        // then
+        assertNotNull(accessToken);
+        log.info("accessToken: {}", accessToken);
+        Claims claims = jwtTokenizer.parseAccessToken(accessToken);
+        log.info("claims: {}", claims);
+        Assertions.assertThat(claims.getSubject()).isEqualTo(userUUID);
+    }
+
+    @DisplayName("UUID와 Role 정보를 이용하여 RefreshToken 생성한다.")
+    @Test
+    void createRefreshToken() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6267";
+        List<String> roles = List.of("ROLE_USER");
+        // when
+        String refreshToken = jwtTokenizer.createRefreshToken(userUUID, roles);
+        // then
+        assertNotNull(refreshToken);
+        log.info("refreshToken: {}", refreshToken);
+        Claims claims = jwtTokenizer.parseAccessToken(refreshToken);
+        log.info("claims: {}", claims);
+        Assertions.assertThat(claims.getSubject()).isEqualTo(userUUID);
+    }
+
+    @DisplayName("AccessToken을 파싱하여 Claims 정보를 추출한다.")
+    @Test
+    void parseAccessToken() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6268";
+        List<String> roles = List.of("ROLE_USER");
+        String accessToken = jwtTokenizer.createAccessToken(userUUID, roles);
+        // when
+        Claims claims = jwtTokenizer.parseAccessToken(accessToken);
+        // then
+        assertNotNull(claims);
+        log.info("claims: {}", claims);
+        Assertions.assertThat(claims.getSubject()).isEqualTo(userUUID);
+    }
+
+    @DisplayName("RefreshToken을 파싱하여 Claims 정보를 추출한다.")
+    @Test
+    void parseRefreshToken() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6269";
+        List<String> roles = List.of("ROLE_USER");
+        String refreshToken = jwtTokenizer.createRefreshToken(userUUID, roles);
+        // when
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
+        // then
+        assertNotNull(claims);
+        log.info("claims: {}", claims);
+        Assertions.assertThat(claims.getSubject()).isEqualTo(userUUID);
+    }
+
+
+}

--- a/src/test/java/com/swyp3/babpool/global/util/jwt/application/JwtServiceImplTest.java
+++ b/src/test/java/com/swyp3/babpool/global/util/jwt/application/JwtServiceImplTest.java
@@ -1,0 +1,101 @@
+package com.swyp3.babpool.global.util.jwt.application;
+
+
+import com.swyp3.babpool.global.util.jwt.JwtTokenizer;
+import com.swyp3.babpool.global.util.jwt.application.response.JwtPairDto;
+import com.swyp3.babpool.global.util.jwt.exception.BabpoolJwtException;
+import com.swyp3.babpool.infra.redis.EmbeddedLocalRedisConfig;
+import com.swyp3.babpool.infra.redis.RedisRepositoryConfig;
+import com.swyp3.babpool.infra.redis.dao.TokenRedisRepository;
+import com.swyp3.babpool.infra.redis.domain.TokenForRedis;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest(classes = {JwtServiceImpl.class, TokenRedisRepository.class, JwtTokenizer.class, EmbeddedLocalRedisConfig.class, RedisRepositoryConfig.class})
+class JwtServiceImplTest {
+
+    @Autowired
+    JwtServiceImpl jwtService;
+    @Autowired
+    TokenRedisRepository tokenRepository;
+
+    @DisplayName("jwt token 쌍이 저장된 jwtPairDto 가 반환된다")
+    @Test
+    void createJwtPair() {
+        // given
+        String userUUID = "46707d92-02f4-4817-8116-a4c3b23e6266";
+        List<String> roles = List.of("ROLE_USER");
+        // when
+        JwtPairDto jwtPairDto = jwtService.createJwtPair(userUUID, roles);
+        // then
+        assertNotNull(jwtPairDto);
+        log.info("jwtPairDto : {}", jwtPairDto);
+        tokenRepository.findById(userUUID).ifPresent(tokenForRedis -> {
+            log.info("tokenForRedis : {}", tokenForRedis);
+            assertEquals(jwtPairDto.getRefreshToken(), tokenForRedis.getRefreshToken());
+        });
+    }
+
+    @DisplayName("refreshToken 으로 accessToken 을 갱신한다")
+    @Test
+    void extendLoginState() {
+        // given
+        String uuid = "0123456789";
+        List<String> roles = List.of("ROLE_USER");
+        Integer refreshExpire = 7;
+
+        JwtTokenizer jwtTokenizer = jwtTokenizer
+                = new JwtTokenizer("12345678901234567890123456789012","12345678901234567890123456789012");
+        String refreshToken = jwtTokenizer.createRefreshToken(uuid, roles);
+
+        tokenRepository.save(TokenForRedis.builder()
+                .refreshToken(refreshToken)
+                .refreshExpire(refreshExpire)
+                .userUUID(uuid)
+                .build());
+        // when
+        String accessToken = jwtService.extendLoginState(refreshToken);
+        // then
+        assertNotNull(accessToken);
+        assertThat(jwtTokenizer.parseRefreshToken(refreshToken).getSubject())
+                .isEqualTo(jwtTokenizer.parseAccessToken(accessToken).getSubject());
+    }
+
+    @DisplayName("refreshToken 으로 로그아웃 처리하면, Redis 에서도 삭제된다.")
+    @Test
+    void logout() {
+        // given
+        String uuid = "0123456789";
+        List<String> roles = List.of("ROLE_USER");
+        Integer refreshExpire = 7;
+
+        JwtTokenizer jwtTokenizer = jwtTokenizer
+                = new JwtTokenizer("12345678901234567890123456789012","12345678901234567890123456789012");
+        String refreshToken = jwtTokenizer.createRefreshToken(uuid, roles);
+
+        tokenRepository.save(TokenForRedis.builder()
+                .refreshToken(refreshToken)
+                .refreshExpire(refreshExpire)
+                .userUUID(uuid)
+                .build());
+        // when
+        jwtService.logout(refreshToken);
+        // then
+        assertThat(tokenRepository.findById(refreshToken)).isEmpty();
+    }
+}

--- a/src/test/java/com/swyp3/babpool/infra/redis/dao/TokenRedisRepositoryTest.java
+++ b/src/test/java/com/swyp3/babpool/infra/redis/dao/TokenRedisRepositoryTest.java
@@ -25,20 +25,21 @@ class TokenRedisRepositoryTest {
     @Test
     void save() {
         // given
-        TokenForRedis tokenForRedis = TokenForRedis.builder()
+        String refreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIwMTIzNDU2Nzg5Iiwicm9sZXMiOiJST0xFX1VTRVIiLCJpYXQiOjE1MTYyMzkwMjJ9.tac5NQLH2MmB-CmUvYllf2ftt2VnxTGRPxd2fHDopyY";
+        TokenForRedis target = TokenForRedis.builder()
                 .userUUID("0123456789")
-                .refreshToken("token-token")
+                .refreshToken(refreshToken)
                 .refreshExpire(10)
                 .build();
         // when
-        TokenForRedis savedToken = tokenRedisRepository.save(tokenForRedis);
+        TokenForRedis savedToken = tokenRedisRepository.save(target);
 
         // then
-        tokenRedisRepository.findById("0123456789")
+        tokenRedisRepository.findById(refreshToken)
                 .ifPresent(token -> {
-                    assertThat(token.getUserUUID()).isEqualTo(savedToken.getUserUUID());
-                    assertThat(token.getRefreshToken()).isEqualTo(savedToken.getRefreshToken());
-                    assertThat(token.getRefreshExpire()).isEqualTo(savedToken.getRefreshExpire()-1);
+                    assertThat(target.getUserUUID()).isEqualTo(savedToken.getUserUUID());
+                    assertThat(target.getRefreshToken()).isEqualTo(savedToken.getRefreshToken());
+                    assertThat(target.getRefreshExpire()).isEqualTo(savedToken.getRefreshExpire());
                 });
     }
 }


### PR DESCRIPTION
Resolves #1 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- JWT 기반의 사용자 인증 처리방식에 필요한 기능들을 구현했습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->

`WebMvcInterceptJwtConfig.java`
- `/api` prefix의 요청에 한해서 jwt access token 을 인증합니다. 
- 해당 파일에서 인증 처리 제외대상 URL을 설정할 수 있습니다.

`JwtServiceImpl`
- 사용자 로그인/회원가입 과정에서 해당 클래스의 public 메서드를 호출해 토큰을 응답할 수 있습니다.
- 회원 관련 Controller에서 필요 시 `JwtServiceImpl` 의 메서드를 호출해서 사용해주세요.

`UserSignOutApi`
- 사용자 로그아웃 처리 과정에서 쿠키를 사용합니다.
- request 으로 부터 쿠키를 꺼내는 것은 역할 분리 관점에서 controller layer의 역할이라고 생각해서 JwtService의 logout 메서드로부터 분리하고, cookie의 필요한 value 만 logout 메서드의 인자로 매개했습니다. 

`JwtTokenInterceptor `
- HandlerInterceptor  클래스의 preHandler 메서드를 재정의해 HTTP Header에 포함된 access token을 검증하고, userId를 커스텀 헤더에 저장합니다.
- 이 과정에서 발생하는 모든 에러는 `BadCredentialsException` 예외를 발생시키며 `JwtExceptionHandler` 클래스가 커스텀 예외 응답을 클라이언트에게 응답합니다.

`JwtAuthenticator`
- 토큰을 검증하는 메서드와 userUuid으로 userId를 반환받는 메서드가 정의되어 있습니다.

`JwtPairDto`
- accessToken과 refreshToken을 전달하는데 사용되는 dto 입니다.
- 클라이언트에게 응답 시, accessToken은 브라우저 localstorage, refreshToken은 https only cookie으로 반환해야 합니다.

`UserUuid`
- uuid를 저장하기 위한 별도의 테이블을 생성했습니다.
- uuid으로 userId를 조회하는 과정에서 발생할 수 있는 예외클래스와 예외핸들러를 생성했습니다.

`TokenRedis`
- uuid를 key로 저장하는 대신 refreshToken을 key로 저장하도록 변경했습니다.

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->

> 참고사항

- 다음 PR 부터는 꼭 세부적인 구현 단위로 나누어 요청하도록 노력하겠습니다.

> 해당 부분을 중점으로 리뷰 요청 드려요

`TokenRedis`
- 현재는 uuid와 expire 값을 Value에 저장하고 있습니다. 어떤 값을 추가로 저장하고 있는 것이 적절할지 의견을 여쭙고 싶습니다.

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->