### PR TITLE
feat(auth): Add social login logic

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
@@ -1,7 +1,17 @@
 package com.swyp3.babpool.domain.user.dao;
 
+import com.swyp3.babpool.domain.user.domain.User;
+import com.swyp3.babpool.infra.auth.AuthPlatform;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface UserRepository {
+    void save(User user);
+
+    Long findUserIdByPlatformAndPlatformId(@Param("platformName") AuthPlatform authPlatform,@Param("platformId") String platformId);
+
+    User findById(Long userId);
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/domain/User.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/domain/User.java
@@ -1,4 +1,35 @@
 package com.swyp3.babpool.domain.user.domain;
 
+import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
 public class User {
+    private Long userId;
+    private String userEmail;
+    private UserStatus userStatus;
+    private UserRole userRole;
+    private String userGrade;
+    private String userNickName;
+    private LocalDateTime userCreateDate;
+    private LocalDateTime userModifyDate;
+
+    //생성 메서드
+    public static User createUser(AuthMemberResponse authMemberResponse) {
+        User user = new User();
+
+        user.userEmail= authMemberResponse.getEmail();
+        user.userStatus = UserStatus.ACTIVE;
+        user.userRole = UserRole.USER;
+        user.userGrade = "none";
+        user.userNickName = authMemberResponse.getNickname();
+        user.userCreateDate = LocalDateTime.now();
+        user.userModifyDate = LocalDateTime.now();
+
+        return user;
+    }
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/domain/User.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.swyp3.babpool.domain.user.domain;
 
 import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,18 +19,15 @@ public class User {
     private LocalDateTime userCreateDate;
     private LocalDateTime userModifyDate;
 
-    //생성 메서드
-    public static User createUser(AuthMemberResponse authMemberResponse) {
-        User user = new User();
-
-        user.userEmail= authMemberResponse.getEmail();
-        user.userStatus = UserStatus.ACTIVE;
-        user.userRole = UserRole.USER;
-        user.userGrade = "none";
-        user.userNickName = authMemberResponse.getNickname();
-        user.userCreateDate = LocalDateTime.now();
-        user.userModifyDate = LocalDateTime.now();
-
-        return user;
+    // 생성자에 @Builder 적용
+    @Builder
+    public User(String email, String nickName) {
+        this.userEmail= email;
+        this.userStatus = UserStatus.ACTIVE;
+        this.userRole = UserRole.USER;
+        this.userGrade = "none";
+        this.userNickName = nickName;
+        this.userCreateDate = LocalDateTime.now();
+        this.userModifyDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/domain/UserRole.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/domain/UserRole.java
@@ -1,0 +1,6 @@
+package com.swyp3.babpool.domain.user.domain;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/swyp3/babpool/domain/user/domain/UserStatus.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package com.swyp3.babpool.domain.user.domain;
+
+public enum UserStatus {
+    EXIT,
+    ACTIVE,
+    BAN
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/AuthJwtParser.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/AuthJwtParser.java
@@ -23,6 +23,7 @@ public class AuthJwtParser {
             String decodedHeader = new String(Base64.getDecoder().decode(encodedHeader));
             return objectMapper.readValue(decodedHeader, Map.class);
         } catch(JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            //TODO: OAuthException 커스텀 에러 필요
             throw new IllegalStateException("JWTParser의 parseHeaders 오류");
         }
     }
@@ -34,8 +35,10 @@ public class AuthJwtParser {
                     .parseClaimsJws(idToken)
                     .getBody();
         }catch(ExpiredJwtException e){
+            //TODO: OAuthException 커스텀 에러 필요
             throw new IllegalStateException("JwtParser 중 오류: 만료된 JWT 토큰입니다.");
         }catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e){
+            //TODO: OAuthException 커스텀 에러 필요
             throw new IllegalStateException("JwtParser 중 오류: 올바르지 않은 토큰입니다.");
         }
     }

--- a/src/main/java/com/swyp3/babpool/infra/auth/PublicKeyGenerator.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/PublicKeyGenerator.java
@@ -36,6 +36,7 @@ public class PublicKeyGenerator {
             KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
             return keyFactory.generatePublic(publicKeySpec);
         }catch(NoSuchAlgorithmException | InvalidKeySpecException exception){
+            //TODO: OAuthException 커스텀 에러 필요
             throw new IllegalStateException("OAuth 로그인 중 public key 생성에 문제가 발생했습니다.");
         }
     }

--- a/src/main/java/com/swyp3/babpool/infra/auth/controller/AuthController.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
 

--- a/src/main/java/com/swyp3/babpool/infra/auth/controller/AuthController.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.swyp3.babpool.infra.auth.controller;
+
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import com.swyp3.babpool.infra.auth.request.LoginRequestDTO;
+import com.swyp3.babpool.infra.auth.response.LoginResponseDTO;
+import com.swyp3.babpool.infra.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/sign/in")
+    public ApiResponse<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO loginRequest){
+        //TODO: @NotNull에 걸렸을 때 커스텀 에러 필요
+        LoginResponseDTO response = authService.kakaoLogin(loginRequest);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/dao/AuthRepository.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/dao/AuthRepository.java
@@ -1,0 +1,11 @@
+package com.swyp3.babpool.infra.auth.dao;
+
+import com.swyp3.babpool.infra.auth.AuthPlatform;
+import com.swyp3.babpool.infra.auth.domain.Auth;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface AuthRepository {
+    void save(Auth oauth);
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/domain/Auth.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/domain/Auth.java
@@ -1,0 +1,30 @@
+package com.swyp3.babpool.infra.auth.domain;
+
+import com.swyp3.babpool.domain.user.domain.User;
+import com.swyp3.babpool.domain.user.domain.UserRole;
+import com.swyp3.babpool.domain.user.domain.UserStatus;
+import com.swyp3.babpool.infra.auth.AuthPlatform;
+import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class Auth {
+    private Long oauthId;
+    private Long userId;
+    private AuthPlatform oauthPlatformName;
+    private String oauthPlatformId;
+
+    public static Auth createAuth(Long userId, AuthPlatform platformName, String platformId) {
+        Auth auth = new Auth();
+
+        auth.userId = userId;
+        auth.oauthPlatformId = platformId;
+        auth.oauthPlatformName = platformName;
+
+        return auth;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoMemberProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoMemberProvider.java
@@ -29,7 +29,7 @@ public class KakaoMemberProvider {
         Claims claims = authJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
 
-        return new KakaoPlatformMemberResponse(claims.getSubject(),claims.get("email",String.class));
+        return new KakaoPlatformMemberResponse(claims.getSubject(),claims.get("nickname",String.class),claims.get("picture",String.class),claims.get("email",String.class));
     }
 
     private void validateClaims(Claims claims) {

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoMemberProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoMemberProvider.java
@@ -2,6 +2,7 @@ package com.swyp3.babpool.infra.auth.kakao;
 
 import com.swyp3.babpool.infra.auth.AuthJwtParser;
 import com.swyp3.babpool.infra.auth.PublicKeyGenerator;
+import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +22,7 @@ public class KakaoMemberProvider {
     @Value("${property.oauth.kakao.client-id}")
     private String clientId;
 
-    public KakaoPlatformMemberResponse getKakaoPlatformMember(String identityToken){
+    public AuthMemberResponse getKakaoPlatformMember(String identityToken){
         Map<String, String> headers = authJwtParser.parseHeaders(identityToken);
         KakaoPublicKeys kakaoPublicKeys = kakaoClient.getKakaoOIDCOpenKeys();
         PublicKey publicKey = publicKeyGenerator.generateKakaoPublicKey(headers, kakaoPublicKeys);
@@ -29,11 +30,12 @@ public class KakaoMemberProvider {
         Claims claims = authJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
 
-        return new KakaoPlatformMemberResponse(claims.getSubject(),claims.get("nickname",String.class),claims.get("picture",String.class),claims.get("email",String.class));
+        return new AuthMemberResponse(claims.getSubject(),claims.get("nickname",String.class),claims.get("picture",String.class),claims.get("email",String.class));
     }
 
     private void validateClaims(Claims claims) {
         if(!claims.getIssuer().contains(iss)&&claims.getAudience().equals(clientId)){
+            //TODO: OAuthException 커스텀 에러 필요
             throw new IllegalStateException("KakaoMemberProvider : OAuth JWT 토큰의 Claim 값이 올바르지 않습니다.");
         }
     }

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoPlatformMemberResponse.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoPlatformMemberResponse.java
@@ -7,5 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class KakaoPlatformMemberResponse {
     private String platformId;
+    private String nickname;
+    private String profile_image;
     private String email;
+
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoPublicKeys.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoPublicKeys.java
@@ -12,6 +12,7 @@ public class KakaoPublicKeys {
     private List<BabpoolPublicKey> keys;
 
     public BabpoolPublicKey getMatchesKey(String kid) {
+        //TODO: OAuthException 커스텀 에러 필요
         return this.keys.stream()
                 .filter(key -> key.getKid().equals(kid))
                 .findFirst()

--- a/src/main/java/com/swyp3/babpool/infra/auth/request/LoginRequestDTO.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/request/LoginRequestDTO.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.infra.auth.request;
+
+import com.swyp3.babpool.infra.auth.AuthPlatform;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDTO {
+    @NotNull
+    private AuthPlatform authPlatform;
+    @NotNull
+    private String idToken;
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/response/AuthMemberResponse.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/response/AuthMemberResponse.java
@@ -1,11 +1,11 @@
-package com.swyp3.babpool.infra.auth.kakao;
+package com.swyp3.babpool.infra.auth.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class KakaoPlatformMemberResponse {
+public class AuthMemberResponse {
     private String platformId;
     private String nickname;
     private String profile_image;

--- a/src/main/java/com/swyp3/babpool/infra/auth/response/LoginResponseDTO.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/response/LoginResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LoginResponseDTO {
-    private Long userId;
+    private String userUuid;
     private String accessToken;
     private Boolean isRegistered;
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/response/LoginResponseDTO.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/response/LoginResponseDTO.java
@@ -1,0 +1,12 @@
+package com.swyp3.babpool.infra.auth.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDTO {
+    private Long userId;
+    private String accessToken;
+    private Boolean isRegistered;
+}

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -24,6 +24,7 @@ public class AuthService {
     private final AuthRepository authRepository;
 
     public LoginResponseDTO kakaoLogin(LoginRequestDTO loginRequest) {
+        //TODO: 들어온 값들 중 NULL 있는지 예외 처리 필요
         AuthMemberResponse kakaoPlatformMember = kakaoMemberProvider.getKakaoPlatformMember(loginRequest.getIdToken());
         return generateLoginResponse(AuthPlatform.KAKAO,kakaoPlatformMember);
     }
@@ -59,14 +60,21 @@ public class AuthService {
     }
 
     private LoginResponseDTO getLoginResponse(User createUser, boolean isRegistered) {
+        //TODO : 현도님 코드 적용 필요
         String accessToken = "accessToken"; //현도님 코드 사용
         String refreshToken = "refreshToken"; //현도님 코드 사용
+        String userUuid = "userUuid"; //후에 현도님 코드 적용 필요
 
-        return new LoginResponseDTO(createUser.getUserId(), accessToken,isRegistered);
+        return new LoginResponseDTO(userUuid, accessToken,isRegistered);
     }
 
     private User createUser(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
-        User user = User.createUser(authMemberResponse);
+
+        User user = User.builder()
+                .email(authMemberResponse.getEmail())
+                .nickName(authMemberResponse.getNickname())
+                .build();
+
         userRepository.save(user);
 
         Long savedId = user.getUserId();

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -1,0 +1,81 @@
+package com.swyp3.babpool.infra.auth.service;
+
+import com.swyp3.babpool.domain.user.dao.UserRepository;
+import com.swyp3.babpool.domain.user.domain.User;
+import com.swyp3.babpool.infra.auth.AuthPlatform;
+import com.swyp3.babpool.infra.auth.domain.Auth;
+import com.swyp3.babpool.infra.auth.kakao.KakaoMemberProvider;
+import com.swyp3.babpool.infra.auth.dao.AuthRepository;
+import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
+import com.swyp3.babpool.infra.auth.request.LoginRequestDTO;
+import com.swyp3.babpool.infra.auth.response.LoginResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final KakaoMemberProvider kakaoMemberProvider;
+    private final UserRepository userRepository;
+    private final AuthRepository authRepository;
+
+    public LoginResponseDTO kakaoLogin(LoginRequestDTO loginRequest) {
+        AuthMemberResponse kakaoPlatformMember = kakaoMemberProvider.getKakaoPlatformMember(loginRequest.getIdToken());
+        return generateLoginResponse(AuthPlatform.KAKAO,kakaoPlatformMember);
+    }
+
+    private LoginResponseDTO generateLoginResponse(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
+        Long findUserId = userRepository.findUserIdByPlatformAndPlatformId(authPlatform, authMemberResponse.getPlatformId());
+
+        //회원가입이 되어있는 경우
+        if(findUserId!=null) {
+            User findUser = userRepository.findById(findUserId);
+            return login(findUser);
+        }
+
+        //회원가입이 필요한 경우
+        return signUp(authPlatform,authMemberResponse);
+    }
+
+    private LoginResponseDTO signUp(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
+        User createUser = createUser(authPlatform, authMemberResponse);
+        log.info("회원가입 성공! 추가적인 정보 입력이 필요합니다.");
+
+        return getLoginResponse(createUser,false);
+    }
+
+    private LoginResponseDTO login(User findUser) {
+        //회원가입은 되어있는데, 추가적인 정보 입력을 하지 않은 경우
+        if(findUser.getUserGrade().equals("none")) {
+            log.info("회원가입은 되어 있으나, 추가적인 정보 입력이 필요합니다.");
+            return getLoginResponse(findUser,false);
+        }
+        log.info("로그인에 성공하였습니다.");
+        return getLoginResponse(findUser,true);
+    }
+
+    private LoginResponseDTO getLoginResponse(User createUser, boolean isRegistered) {
+        String accessToken = "accessToken"; //현도님 코드 사용
+        String refreshToken = "refreshToken"; //현도님 코드 사용
+
+        return new LoginResponseDTO(createUser.getUserId(), accessToken,isRegistered);
+    }
+
+    private User createUser(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
+        User user = User.createUser(authMemberResponse);
+        userRepository.save(user);
+
+        Long savedId = user.getUserId();
+
+        Auth auth = Auth.createAuth(savedId, authPlatform, authMemberResponse.getPlatformId());
+        authRepository.save(auth);
+
+        return user;
+    }
+
+}
+

--- a/src/main/resources/mapper/AuthMapper.xml
+++ b/src/main/resources/mapper/AuthMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.infra.auth.dao.AuthRepository">
+
+    <insert id="save" useGeneratedKeys="true" keyProperty="oauthId">
+        insert into t_oauth(user_id,oauth_platform_name,oauth_platform_id)
+        values ( #{userId},#{oauthPlatformName},#{oauthPlatformId} )
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.domain.user.dao.UserRepository">
+
+    <insert id="save" useGeneratedKeys="true" keyProperty="userId">
+        insert into t_user_account(user_email,user_status,user_role,user_grade,user_nick_name,user_create_date,user_modify_date)
+        values ( #{userEmail},#{userStatus},#{userRole},#{userGrade},#{userNickName},#{userCreateDate},#{userModifyDate} )
+    </insert>
+
+    <select id="findById" resultType="com.swyp3.babpool.domain.user.domain.User">
+        select user_id,user_email,user_status,user_role,user_grade,user_nick_name,user_create_date,user_modify_date
+        from t_user_account
+        where user_id = #{userId}
+    </select>
+
+    <select id="findUserIdByPlatformAndPlatformId" resultType="Long">
+        select u.user_id
+        from t_user_account u
+        join t_oauth o on u.user_id = o.user_id
+        where o.oauth_platform_name = #{platformName} and o.oauth_platform_id = #{platformId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
Resolves #9
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 프론트로부터 받은 idToken으로 이미 회원가입되어있는 회원인지, 회원가입이 필요한 회원인지 응답

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- DTO 추가
  - LoginResponseDTO : userid(후에 userUUID로 변환 예정), accessToken, isRegistered(회원가입 여부)
  - LoginRequestDTO : 소셜로그인 플랫폼명, idToken 값
- 회원 정보 조회 및 저장을 위한 클래스 생성
  - User, Auth 도메인
  - User, Auth Repository
  - User, Auth mapper 파일
- Enum 클래스 추가
  - UserStatus, UserRole
  
추가적으로 예외 처리와 accessToken과 refreshToken을 적용한 응답을 구현해야합니다.  

### Reference

<!-- 참고 자료 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->