### PR TITLE
feat(profile): Add overall structure of the profile domain

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
@@ -1,0 +1,26 @@
+package com.swyp3.babpool.domain.profile.api;
+
+import com.swyp3.babpool.domain.profile.api.request.ProfileUpdateRequest;
+import com.swyp3.babpool.domain.profile.application.ProfileService;
+import com.swyp3.babpool.domain.profile.application.response.ProfileUpdateResponse;
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ProfileApi {
+
+    private final ProfileService profileService;
+
+    @PostMapping("/api/profile/card")
+    public ApiResponse<ProfileUpdateResponse> updateProfileCard(@RequestAttribute(value = "userId") Long userId,
+                                                                @RequestPart(value = "profileImageFile") MultipartFile multipartFile,
+                                                                @RequestPart(value = "profileInfo") ProfileUpdateRequest profileUpdateRequest) {
+        profileService.uploadProfileImage(userId, multipartFile);
+        ProfileUpdateResponse profileResponse = profileService.saveProfileInfo(userId, profileUpdateRequest);
+        return ApiResponse.ok(profileResponse);
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
@@ -1,0 +1,28 @@
+package com.swyp3.babpool.domain.profile.api;
+
+import com.swyp3.babpool.domain.profile.api.request.ProfileListRequest;
+import com.swyp3.babpool.domain.profile.application.ProfileService;
+import com.swyp3.babpool.domain.profile.application.response.ProfileResponse;
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ProfilePermitApi {
+
+    private final ProfileService profileService;
+
+    @GetMapping("/api/profile/list")
+    public ApiResponse<List<ProfileResponse>> getProfileList(@RequestParam String searchTerm,
+                                                             @RequestParam List<String> keywords) {
+        return ApiResponse.ok(profileService.getProfileListInConditionsOf(ProfileListRequest.builder()
+                .searchTerm(searchTerm)
+                .keywords(keywords)
+                .build()));
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/api/request/ProfileListRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/request/ProfileListRequest.java
@@ -1,0 +1,21 @@
+package com.swyp3.babpool.domain.profile.api.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class ProfileListRequest {
+
+    private String searchTerm;
+    private List<String> keywords;
+
+    @Builder
+    public ProfileListRequest(String searchTerm, List<String> keywords) {
+        this.searchTerm = searchTerm;
+        this.keywords = keywords;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/api/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/request/ProfileUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.swyp3.babpool.domain.profile.api.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ProfileUpdateRequest {
+
+    private String profileIntro;
+    private String profileContents;
+    private String profileContactPhone;
+    private String profileContactChat;
+
+    @Builder
+    public ProfileUpdateRequest(String profileIntro, String profileContents, String profileContactPhone, String profileContactChat) {
+        this.profileIntro = profileIntro;
+        this.profileContents = profileContents;
+        this.profileContactPhone = profileContactPhone;
+        this.profileContactChat = profileContactChat;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileService.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileService.java
@@ -1,0 +1,18 @@
+package com.swyp3.babpool.domain.profile.application;
+
+import com.swyp3.babpool.domain.profile.api.request.ProfileListRequest;
+import com.swyp3.babpool.domain.profile.api.request.ProfileUpdateRequest;
+import com.swyp3.babpool.domain.profile.application.response.ProfileResponse;
+import com.swyp3.babpool.domain.profile.application.response.ProfileUpdateResponse;
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ProfileService {
+    List<ProfileResponse> getProfileListInConditionsOf(ProfileListRequest profileListRequest);
+
+    String uploadProfileImage(Long userId, MultipartFile multipartFile);
+
+    ProfileUpdateResponse saveProfileInfo(Long userId, ProfileUpdateRequest profileUpdateRequest);
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -1,0 +1,46 @@
+package com.swyp3.babpool.domain.profile.application;
+
+import com.swyp3.babpool.domain.profile.api.request.ProfileListRequest;
+import com.swyp3.babpool.domain.profile.api.request.ProfileUpdateRequest;
+import com.swyp3.babpool.domain.profile.application.response.ProfileResponse;
+import com.swyp3.babpool.domain.profile.application.response.ProfileUpdateResponse;
+import com.swyp3.babpool.domain.profile.dao.ProfileRepository;
+import com.swyp3.babpool.domain.profile.domain.Profile;
+//import com.swyp3.babpool.infra.s3.application.AwsS3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileServiceImpl implements ProfileService{
+
+//    private final AwsS3Uploader awsS3Uploader;
+    private final ProfileRepository profileRepository;
+
+    @Override
+    public List<ProfileResponse> getProfileListInConditionsOf(ProfileListRequest profileListRequest) {
+        return profileRepository.findByUserIdAndSearchTermAndKeywords(profileListRequest).stream()
+                .map(ProfileResponse::from)
+                .toList();
+    }
+
+    @Override
+    public String uploadProfileImage(Long userId, MultipartFile multipartFile) {
+//        String uploadedImageUrl = awsS3Uploader.uploadImage(multipartFile);
+        String uploadedImageUrl = "";
+        profileRepository.saveProfileImageUrl(Profile.builder()
+                .userId(userId)
+                .profileImageUrl(uploadedImageUrl)
+                .build());
+        return uploadedImageUrl;
+    }
+
+    @Override
+    public ProfileUpdateResponse saveProfileInfo(Long userId, ProfileUpdateRequest profileUpdateRequest) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfileResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfileResponse.java
@@ -1,0 +1,39 @@
+package com.swyp3.babpool.domain.profile.application.response;
+
+import com.swyp3.babpool.domain.profile.domain.Profile;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ProfileResponse {
+
+    private Long profileId;
+    private String profileImageUrl;
+    private String profileIntro;
+    private String profileContents;
+    private String profileContactPhone;
+    private String profileContactChat;
+
+    @Builder
+    public ProfileResponse(Long profileId, String profileImageUrl, String profileIntro, String profileContents, String profileContactPhone, String profileContactChat) {
+        this.profileId = profileId;
+        this.profileImageUrl = profileImageUrl;
+        this.profileIntro = profileIntro;
+        this.profileContents = profileContents;
+        this.profileContactPhone = profileContactPhone;
+        this.profileContactChat = profileContactChat;
+    }
+
+    public static ProfileResponse from(Profile profile) {
+        return ProfileResponse.builder()
+                .profileId(profile.getProfileId())
+                .profileImageUrl(profile.getProfileImageUrl())
+                .profileIntro(profile.getProfileIntro())
+                .profileContents(profile.getProfileContents())
+                .profileContactPhone(profile.getProfileContactPhone())
+                .profileContactChat(profile.getProfileContactChat())
+                .build();
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfileUpdateResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfileUpdateResponse.java
@@ -1,0 +1,25 @@
+package com.swyp3.babpool.domain.profile.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ProfileUpdateResponse {
+
+    private String profileImageUrl;
+    private String profileIntro;
+    private String profileContents;
+    private String profileContactPhone;
+    private String profileContactChat;
+
+    @Builder
+    public ProfileUpdateResponse(String profileImageUrl, String profileIntro, String profileContents, String profileContactPhone, String profileContactChat) {
+        this.profileImageUrl = profileImageUrl;
+        this.profileIntro = profileIntro;
+        this.profileContents = profileContents;
+        this.profileContactPhone = profileContactPhone;
+        this.profileContactChat = profileContactChat;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/dao/ProfileRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/dao/ProfileRepository.java
@@ -1,0 +1,16 @@
+package com.swyp3.babpool.domain.profile.dao;
+
+import com.swyp3.babpool.domain.profile.api.request.ProfileListRequest;
+import com.swyp3.babpool.domain.profile.domain.Profile;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+public interface ProfileRepository {
+
+    void saveProfileImageUrl(Profile profile);
+
+    List<Profile> findByUserIdAndSearchTermAndKeywords(ProfileListRequest profileListRequest);
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/domain/Profile.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/domain/Profile.java
@@ -1,0 +1,31 @@
+package com.swyp3.babpool.domain.profile.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class Profile {
+
+    private Long profileId;
+    private Long userId;
+    private String profileImageUrl;
+    private String profileIntro;
+    private String profileContents;
+    private String profileContactPhone;
+    private String profileContactChat;
+    private Boolean profileActiveFlag;
+
+    @Builder
+    public Profile(Long profileId, Long userId, String profileImageUrl, String profileIntro, String profileContents, String profileContactPhone, String profileContactChat, Boolean profileActiveFlag) {
+        this.profileId = profileId;
+        this.userId = userId;
+        this.profileImageUrl = profileImageUrl;
+        this.profileIntro = profileIntro;
+        this.profileContents = profileContents;
+        this.profileContactPhone = profileContactPhone;
+        this.profileContactChat = profileContactChat;
+        this.profileActiveFlag = profileActiveFlag;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/exception/ProfileException.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/exception/ProfileException.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.domain.profile.exception;
+
+import com.swyp3.babpool.domain.profile.exception.errorcode.ProfileErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ProfileException extends RuntimeException{
+
+    private final ProfileErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/exception/errorcode/ProfileErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/exception/errorcode/ProfileErrorCode.java
@@ -1,0 +1,16 @@
+package com.swyp3.babpool.domain.profile.exception.errorcode;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProfileErrorCode implements CustomErrorCode {
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/exception/handler/ProfileExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/exception/handler/ProfileExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.swyp3.babpool.domain.profile.exception.handler;
+
+import com.swyp3.babpool.domain.profile.exception.ProfileException;
+import com.swyp3.babpool.global.common.response.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ProfileExceptionHandler {
+
+    @ExceptionHandler
+    protected ApiErrorResponse handleProfileException(ProfileException exception){
+        log.error("ProfileException getProfileErrorCode() >> "+exception.getErrorCode());
+        log.error("ProfileException getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getErrorCode());
+    }
+}

--- a/src/main/resources/mapper/ProfileMapper.xml
+++ b/src/main/resources/mapper/ProfileMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.domain.profile.dao.ProfileRepository">
+
+    <insert id="saveProfileImageUrl" parameterType="com.swyp3.babpool.domain.profile.domain.Profile">
+        INSERT INTO t_profile (profile_image_url) VALUES (#{profileImageUrl}) where user_id = #{userId}
+    </insert>
+
+
+</mapper>


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- profile 도메인 하위에서 사용할 전반적인 구조를 추가했습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 기획을 근거하여 `"/api/profile/list"` 요청은 검증 없이 허용됩니다.
- 화면정의서에 근거하여 프로필 이미지 변경과 그 외 텍스트 정보 변경을 하나의 API 으로  요청받아 처리합니다.
- response 에서 유저 식별 값 반환이 필요한 경우 `userId`(내부 식별 값) 가 아닌 `userUuid`(외부 식별 값) 를 반환하도록 구현했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 주석 처리 된 `AwsS3Uploader` 는 별도의 `feature/s3` 브랜치에서 PR 요청 드리겠습니다.
- Mapper 의 쿼리는 작성되어 있지 않습니다.
- 추후 `ProfileService` 클래스의 `saveProfileInfo` 메서드를 구현 부탁드립니다.

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->