### PR TITLE
feat(s3): Add s3 image upload and delete feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 
     implementation 'com.fasterxml.uuid:java-uuid-generator:4.3.0'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -6,7 +6,7 @@ import com.swyp3.babpool.domain.profile.application.response.ProfileResponse;
 import com.swyp3.babpool.domain.profile.application.response.ProfileUpdateResponse;
 import com.swyp3.babpool.domain.profile.dao.ProfileRepository;
 import com.swyp3.babpool.domain.profile.domain.Profile;
-//import com.swyp3.babpool.infra.s3.application.AwsS3Uploader;
+import com.swyp3.babpool.infra.s3.application.AwsS3Provider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProfileServiceImpl implements ProfileService{
 
-//    private final AwsS3Uploader awsS3Uploader;
+    private final AwsS3Provider awsS3Provider;
     private final ProfileRepository profileRepository;
 
     @Override
@@ -29,8 +29,7 @@ public class ProfileServiceImpl implements ProfileService{
 
     @Override
     public String uploadProfileImage(Long userId, MultipartFile multipartFile) {
-//        String uploadedImageUrl = awsS3Uploader.uploadImage(multipartFile);
-        String uploadedImageUrl = "";
+        String uploadedImageUrl = awsS3Provider.uploadImage(multipartFile);
         profileRepository.saveProfileImageUrl(Profile.builder()
                 .userId(userId)
                 .profileImageUrl(uploadedImageUrl)

--- a/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
@@ -13,7 +13,7 @@ public class WebMvcInterceptJwtConfig implements WebMvcConfigurer {
     private final JwtTokenInterceptor jwtTokenInterceptor;
     private static final String[] EXCLUDE_PATHS = {
         "/api/user/sign/in", "/api/user/sign/up", "/api/user/sign/out", "/api/user/sign/refresh",
-        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens", "/api/test/image/upload",
+        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens", "/api/test/image/upload", "/api/test/image/delete",
         "/api/profile/list"
     };
 

--- a/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
@@ -13,7 +13,7 @@ public class WebMvcInterceptJwtConfig implements WebMvcConfigurer {
     private final JwtTokenInterceptor jwtTokenInterceptor;
     private static final String[] EXCLUDE_PATHS = {
         "/api/user/sign/in", "/api/user/sign/up", "/api/user/sign/out", "/api/user/sign/refresh",
-        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens",
+        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens", "/api/test/image/upload",
         "/api/profile/list"
     };
 

--- a/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckS3Api.java
+++ b/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckS3Api.java
@@ -1,0 +1,21 @@
+package com.swyp3.babpool.infra.health.api;
+
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import com.swyp3.babpool.infra.s3.application.AwsS3Provider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class HealthCheckS3Api {
+
+    private final AwsS3Provider awsS3Provider;
+
+    @PostMapping("/api/test/image/upload")
+    public ApiResponse<String> testImageUpload(@RequestPart("profileImageFile")MultipartFile multipartFile){
+        return ApiResponse.ok(awsS3Provider.uploadImage(multipartFile));
+    }
+}

--- a/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckS3Api.java
+++ b/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckS3Api.java
@@ -4,9 +4,12 @@ import com.swyp3.babpool.global.common.response.ApiResponse;
 import com.swyp3.babpool.infra.s3.application.AwsS3Provider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,4 +21,11 @@ public class HealthCheckS3Api {
     public ApiResponse<String> testImageUpload(@RequestPart("profileImageFile")MultipartFile multipartFile){
         return ApiResponse.ok(awsS3Provider.uploadImage(multipartFile));
     }
+
+    @PostMapping("/api/test/image/delete")
+    public ApiResponse<String> testImageDelete(@RequestBody Map<String, String> param){
+        awsS3Provider.deleteImage(param.get("imageUrl"));
+        return ApiResponse.ok("S3 이미지 삭제에 성공했습니다.");
+    }
+
 }

--- a/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
@@ -1,0 +1,55 @@
+package com.swyp3.babpool.infra.s3.application;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.fasterxml.uuid.Generators;
+import com.swyp3.babpool.infra.s3.exception.AwsS3ErrorCode;
+import com.swyp3.babpool.infra.s3.exception.AwsS3Exception;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsS3Provider {
+    private static final String S3_BUCKET_DIRECTORY_NAME = "static";
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    public String uploadImage(MultipartFile multipartFile) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+        String fileName = S3_BUCKET_DIRECTORY_NAME + "/" + Generators.timeBasedEpochGenerator().generate() + "." + multipartFile.getOriginalFilename();
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            log.error("S3 파일 업로드에 실패했습니다. {}", e.getMessage());
+            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_IMAGE_UPLOAD_FAIL, "Aws s3 image upload fail, in AwsS3Uploader.uploadImage() method.");
+        }
+        log.info("S3 파일 업로드에 성공했습니다. 파일명: {}", fileName);
+        String imageUrl = amazonS3Client.getUrl(bucket, fileName).toString();
+        log.info("S3 파일 URL: {}", imageUrl);
+        return imageUrl;
+    }
+
+
+
+}

--- a/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
@@ -1,55 +1,95 @@
 package com.swyp3.babpool.infra.s3.application;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fasterxml.uuid.Generators;
 import com.swyp3.babpool.infra.s3.exception.AwsS3ErrorCode;
 import com.swyp3.babpool.infra.s3.exception.AwsS3Exception;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AwsS3Provider {
     private static final String S3_BUCKET_DIRECTORY_NAME = "static";
-
+    private static final Map<String, Boolean> S3_ALLOWED_IMAGE_FILE_TYPES = Map.of(
+            "image/jpeg", true,
+            "image/png", true,
+            "image/gif", true
+    );
+    private static final Integer S3_MAX_IMAGE_FILE_SIZE = 5_000_000; // 5MB
     private final AmazonS3 amazonS3Client;
-
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
 
-    public String uploadImage(MultipartFile multipartFile) {
+    public String uploadImage(@NotNull MultipartFile multipartFile) {
+        validateImageFileType(multipartFile.getContentType());
+        validateImageFileSize(multipartFile.getSize());
+
+        String fileName = generateFileName(multipartFile.getOriginalFilename());
+        uploadToS3Bucket(multipartFile, fileName);
+
+        String imageUrl = amazonS3Client.getUrl(bucket, fileName).toString();
+        log.info("S3 파일 업로드에 성공. URL: {}", imageUrl);
+        return imageUrl;
+    }
+
+    private void uploadToS3Bucket(MultipartFile multipartFile, String fileName) {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentType(multipartFile.getContentType());
         objectMetadata.setContentLength(multipartFile.getSize());
-
-        String fileName = S3_BUCKET_DIRECTORY_NAME + "/" + Generators.timeBasedEpochGenerator().generate() + "." + multipartFile.getOriginalFilename();
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (IOException e) {
             log.error("S3 파일 업로드에 실패했습니다. {}", e.getMessage());
-            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_IMAGE_UPLOAD_FAIL, "Aws s3 image upload fail, in AwsS3Uploader.uploadImage() method.");
+            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_IMAGE_UPLOAD_FAIL,
+                    "Aws s3 image upload fail, in AwsS3Uploader.uploadImage() method.");
         }
-        log.info("S3 파일 업로드에 성공했습니다. 파일명: {}", fileName);
-        String imageUrl = amazonS3Client.getUrl(bucket, fileName).toString();
-        log.info("S3 파일 URL: {}", imageUrl);
-        return imageUrl;
     }
 
+    private String generateFileName(String originalFileName) {
+        return S3_BUCKET_DIRECTORY_NAME + "/" + Generators.timeBasedEpochGenerator().generate() + "." + originalFileName;
+    }
 
+    private void validateImageFileType(String targetContentType) {
+        if (!S3_ALLOWED_IMAGE_FILE_TYPES.containsKey(targetContentType)) {
+            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_INVALID_FILE_TYPE,
+                    "Invalid file type. Only JPEG and PNG are supported.");
+        }
+    }
+
+    private void validateImageFileSize(Long targetSize) {
+        if (targetSize > S3_MAX_IMAGE_FILE_SIZE) { // 5MB
+            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_FILE_TOO_LARGE,
+                    "File size is too large. Maximum allowed size is 5MB.");
+        }
+    }
+
+    public boolean deleteImage(String imageUrlFromProfileRepository) {
+        String fileName = S3_BUCKET_DIRECTORY_NAME + imageUrlFromProfileRepository.substring(imageUrlFromProfileRepository.lastIndexOf("/"));
+        try {
+            amazonS3Client.deleteObject(bucket, fileName);
+        } catch (Exception e) {
+            log.error("S3 파일 삭제에 실패했습니다. {}", e.getMessage());
+            throw new AwsS3Exception(AwsS3ErrorCode.AWS_S3_IMAGE_DELETE_FAIL,
+                    "Aws s3 image delete fail, in AwsS3Uploader.deleteImage() method.");
+        }
+        return true;
+    }
 
 }

--- a/src/main/java/com/swyp3/babpool/infra/s3/config/S3Config.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.swyp3.babpool.infra.s3.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ErrorCode.java
@@ -1,0 +1,19 @@
+package com.swyp3.babpool.infra.s3.exception;
+
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+//import org.apache.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AwsS3ErrorCode implements CustomErrorCode {
+
+    AWS_S3_IMAGE_UPLOAD_FAIL(HttpStatus.FAILED_DEPENDENCY, "Aws s3 image upload fail."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ErrorCode.java
@@ -12,7 +12,9 @@ import org.springframework.http.HttpStatus;
 public enum AwsS3ErrorCode implements CustomErrorCode {
 
     AWS_S3_IMAGE_UPLOAD_FAIL(HttpStatus.FAILED_DEPENDENCY, "Aws s3 image upload fail."),
-    ;
+    AWS_S3_INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "Invalid file type. Only JPEG and PNG are supported."),
+    AWS_S3_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "File size is too large. Maximum allowed size is 5MB."),
+    AWS_S3_IMAGE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "Aws s3 image delete fail.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3Exception.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3Exception.java
@@ -1,0 +1,12 @@
+package com.swyp3.babpool.infra.s3.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AwsS3Exception extends RuntimeException{
+
+    private final AwsS3ErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/exception/AwsS3ExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.swyp3.babpool.infra.s3.exception;
+
+import com.swyp3.babpool.global.common.response.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class AwsS3ExceptionHandler {
+
+    @ExceptionHandler(AwsS3Exception.class)
+    protected ApiErrorResponse handleAwsS3Exception(AwsS3Exception exception){
+        log.error("AwsS3Exception getErrorCode() >> "+exception.getErrorCode());
+        log.error("AwsS3Exception getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/swyp3/babpool/infra/s3/application/AwsS3ProviderTest.java
+++ b/src/test/java/com/swyp3/babpool/infra/s3/application/AwsS3ProviderTest.java
@@ -1,0 +1,22 @@
+package com.swyp3.babpool.infra.s3.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+class AwsS3ProviderTest {
+
+    @DisplayName("S3 이미지 삭제 요청 URL에서 파일명 추출 테스트")
+    @Test
+    void extractFileNameFromDeleteRequestUrl() {
+
+        String imageUrlFromProfileRepository = "https://babpool-image-bucket.s3.ap-northeast-2.amazonaws.com/static/018df2dd-6b59-7758-9e76-2862767ce099.center-username-notion-avatar-1707464623232.png";
+        String fileName = "static" + imageUrlFromProfileRepository.substring(imageUrlFromProfileRepository.lastIndexOf("/"));
+        log.info("fileName = {}", fileName);
+    }
+
+
+}


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- AWS S3 bucket 이미지 업로드 및 삭제 기능 구현

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `AwsS3Provider` 클래스에 `uploadImage` 메서드와 `deleteImage` 메서드를 구현했습니다.
   - 이미지 업로드 과정에서, 파일 확장자와 최대 파일 크기를 검증했습니다.
- 파일 명 중복 방지를 위해 생성 시간 기반 UUID 를 생성해 파일 명을 생성했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->

해당 부분을 중점으로 리뷰를 부탁드립니다.
- 이미지 삭제 시, 데이터베이스에 저장된 이미지 URL 을 활용해 삭제하기 때문에 S3 bucket에 해당 이미지 파일이 실존하는지 검증 과정을 포함하지 않았습니다. 혹여 결함이 발생할 수 있는 상황이 있을까요? 
- 이미지 삭제 시, URL에서 파일 명을 추출하는 코드가 의도한 대로 동작하지 않을 가능성이 있을까요? 
   - [해당 링크](https://blog.naver.com/btdays/220655060962)와 같이 사용자가 파일명에 `/` 문자를 포함할 경우

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->