### PR TITLE
refactor(cookie): Update ApiResponseWithCookie to set domain and expi…

### DIFF
--- a/src/main/java/com/swyp3/babpool/global/common/response/ApiResponseWithCookie.java
+++ b/src/main/java/com/swyp3/babpool/global/common/response/ApiResponseWithCookie.java
@@ -2,6 +2,7 @@ package com.swyp3.babpool.global.common.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 
@@ -12,50 +13,50 @@ import java.util.Map;
 @Getter
 public class ApiResponseWithCookie<T> {
 
+    @Value("${property.cookie.domain}")
+    private static String domain;
+    @Value("${property.jwt.refreshTokenExpireDays}")
+    private static Integer refreshTokenExpireDays;
 
     private final LocalDateTime timestamp = LocalDateTime.now();
     private int code;
     private HttpStatus status;
     private String message;
     private T data;
-    private List<ResponseCookie> cookies;
+    private ResponseCookie cookie;
 
-    public ApiResponseWithCookie(HttpStatus status, String message, T data, List<ResponseCookie> cookies) {
+    public ApiResponseWithCookie(HttpStatus status, String message, T data, ResponseCookie cookie) {
         this.code = status.value();
         this.status = status;
         this.message = message;
         this.data = data;
-        this.cookies = cookies;
+        this.cookie = cookie;
     }
 
     @Builder
-    public static <T> ApiResponseWithCookie<T> ofMultipleCookies(HttpStatus status, String message, T data, Map<String, String> cookiesKeyValue, String clientDomain, Integer times) {
-        List<ResponseCookie> cookies = cookiesKeyValue.entrySet().stream()
-                .map(entry -> createCookie(entry.getKey(), entry.getValue(), clientDomain, times))
-                .toList();
-        return new ApiResponseWithCookie<>(status, message, data, cookies);
+    public static <T> ApiResponseWithCookie<T> ofCookie(HttpStatus status, String message, T data, String key, String value, boolean httpOnlyFlag, Integer expireDays) {
+        ResponseCookie cookie = ResponseCookie.from(key, value)
+                .domain(domain)
+                .httpOnly(httpOnlyFlag)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * expireDays)
+                .build();
+        return new ApiResponseWithCookie<>(status, message, data, cookie);
     }
 
     @Builder
-    public static <T> ApiResponseWithCookie<T> of(HttpStatus status, String message, T data, String cookieKey, String cookieValue, String clientDomain, Integer times) {
-        return new ApiResponseWithCookie<>(status, message, data, List.of(createCookie(cookieKey, cookieValue, clientDomain, times)));
-    }
-
-    @Builder
-    public static <T> ApiResponseWithCookie<T> ofRefreshToken(HttpStatus status, String message, T data, String refreshToken, String clientDomain, Integer times) {
-        List<ResponseCookie> cookies = List.of(createCookie("refreshToken", refreshToken, clientDomain, times));
-        return new ApiResponseWithCookie<>(status, message, data, cookies);
-    }
-
-    private static ResponseCookie createCookie(String key, String value, String domain, Integer times) {
-        return ResponseCookie.from(key, value)
+    public static <T> ApiResponseWithCookie<T> ofRefreshToken(HttpStatus status, String message, T data, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .domain(domain)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
                 .path("/")
-                .maxAge(60 * 60 * times)
+                .maxAge(60 * 60 * 24 * refreshTokenExpireDays)
                 .build();
+        return new ApiResponseWithCookie<>(status, message, data, cookie);
     }
 
 }


### PR DESCRIPTION
Resolves #17 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- `ApiResponseWithCookie` 가 도메인과 쿠키 만료기한을 지정하도록 개선

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- ApiResponseWithCookie의 ofRefreshToken 메서드를 호출하는 클라이언트에서 도메인과 쿠키 만료기한을 지정하는 부분을 ApiResponseWithCookie 가 설정파일의 값을 참조해 호출 클라이언트가 지정하지 않도록 개선했습니다.
- 또한 List<ResponseCookie> 형태로 여러 쿠키를 반환하는 대신, 한 번에 하나의 쿠키를 반환하도록 변경했습니다.
  - `ofMultipleCookies` 메서드를 삭제하고 `ofCookie` 를 추가했습니다. 

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
 - refreshToken을 쿠키로 담아 응답할 경우 `ofRefreshToken(HttpStatus status, String message, T data, String refreshToken)` 메서드를 사용하시면 됩니다. 
 - `HttpStatus status, String message` 를 추가적으로 매개 받는 이유는 회원가입/토큰재발급 의 세부 응답을 status와 message으로 구분하기 위함입니다.

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->