### PR TITLE
feat(profile): Add paging sort type recent profile modify date as default

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
@@ -22,7 +22,7 @@ public class ProfilePermitApi {
     private final ProfileService profileService;
 
     @GetMapping("/api/profile/list")
-    public ApiResponse<Page<ProfilePagingResponse>> getProfileListWithPageable(@RequestParam String searchTerm,
+    public ApiResponse<Page<ProfilePagingResponse>> getProfileListWithPageable(@RequestParam(required = false) String searchTerm,
                                                                                @RequestParam List<String> userGrades,
                                                                                @RequestParam List<String> keywords,
                                                                                @PageableDefault(size = 10) Pageable pageable){

--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfilePermitApi.java
@@ -8,7 +8,9 @@ import com.swyp3.babpool.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,10 +24,12 @@ public class ProfilePermitApi {
     private final ProfileService profileService;
 
     @GetMapping("/api/profile/list")
-    public ApiResponse<Page<ProfilePagingResponse>> getProfileListWithPageable(@RequestParam(required = false) String searchTerm,
-                                                                               @RequestParam List<String> userGrades,
-                                                                               @RequestParam List<String> keywords,
-                                                                               @PageableDefault(size = 10) Pageable pageable){
+    public ApiResponse<Page<ProfilePagingResponse>> getProfileListWithPageable(
+            @RequestParam(required = false) String searchTerm,
+            @RequestParam List<String> userGrades,
+            @RequestParam List<String> keywords,
+            @PageableDefault(size = 10)
+            @SortDefault(sort = "profile_modify_date", direction = Sort.Direction.DESC) Pageable pageable){
         return ApiResponse.ok(profileService.getProfileListWithPageable(ProfilePagingConditions.builder()
                 .search(searchTerm)
                 .userGrades(userGrades)

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfilePagingResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfilePagingResponse.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @ToString
 @Getter
@@ -15,22 +17,18 @@ public class ProfilePagingResponse {
     private String profileImageUrl;
     private String profileIntro;
     private String profileContents;
-    private String profileContactPhone;
-    private String profileContactChat;
-    private Boolean profileActiveFlag;
-    private String keywordIdWithNameString;
-    private String userGrade;
+    private LocalDateTime profileModifyDate; // t_profile 테이블의 profile_modify_date
+    private String keywordIdWithNameString; // t_keyword 테이블의 keyword_id와 keyword_name을 합친 문자열
+    private String userGrade; // t_user_account 테이블의 user_grade
 
     @Builder
-    public ProfilePagingResponse(Long profileId, Long userId, String profileImageUrl, String profileIntro, String profileContents, String profileContactPhone, String profileContactChat, Boolean profileActiveFlag, String keywordIdWithNameString, String userGrade) {
+    public ProfilePagingResponse(Long profileId, Long userId, String profileImageUrl, String profileIntro, String profileContents, LocalDateTime profileModifyDate, String keywordIdWithNameString, String userGrade) {
         this.profileId = profileId;
         this.userId = userId;
         this.profileImageUrl = profileImageUrl;
         this.profileIntro = profileIntro;
         this.profileContents = profileContents;
-        this.profileContactPhone = profileContactPhone;
-        this.profileContactChat = profileContactChat;
-        this.profileActiveFlag = profileActiveFlag;
+        this.profileModifyDate = profileModifyDate;
         this.keywordIdWithNameString = keywordIdWithNameString;
         this.userGrade = userGrade;
     }

--- a/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
@@ -1,0 +1,55 @@
+package com.swyp3.babpool.domain.profile.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Slf4j
+@Configuration
+public class PagingSortTypeMappingConfig implements WebMvcConfigurer {
+
+    private static final String DEFAULT_PROFILE_MODIFY_DATE = "profile_modify_date";
+    private static final String NAME = "user_name";
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        SortHandlerMethodArgumentResolver sortResolver = new SortHandlerMethodArgumentResolver();
+        resolvers.add(new PageableHandlerMethodArgumentResolver(sortResolver) {
+            @Override
+            public Pageable resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+                Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+                Sort newSort = Sort.unsorted();
+                Sort currentSort = pageable.getSort();
+
+                if (currentSort != null && !currentSort.isEmpty()) {
+                    for (Sort.Order order : currentSort) {
+                        String convertToDatabaseColumnNameForSorting = null;
+                        switch (order.getProperty()) {
+                            case "이름순":
+                                convertToDatabaseColumnNameForSorting = NAME;
+                                break;
+                            default:
+                                convertToDatabaseColumnNameForSorting = DEFAULT_PROFILE_MODIFY_DATE;
+                        }
+
+                        Sort.Direction direction = order.getDirection();
+                        newSort = Sort.by(Sort.Order.by(convertToDatabaseColumnNameForSorting).with(direction));
+                    }
+                }
+                return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), newSort);
+            }
+        });
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
@@ -1,5 +1,6 @@
 package com.swyp3.babpool.domain.profile.config;
 
+import com.swyp3.babpool.domain.profile.domain.ProfileSortType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.MethodParameter;
@@ -20,8 +21,6 @@ import java.util.List;
 @Configuration
 public class PagingSortTypeMappingConfig implements WebMvcConfigurer {
 
-    private static final String DEFAULT_PROFILE_MODIFY_DATE = "profile_modify_date";
-    private static final String NAME = "user_name";
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -37,11 +36,11 @@ public class PagingSortTypeMappingConfig implements WebMvcConfigurer {
                     for (Sort.Order order : currentSort) {
                         String convertToDatabaseColumnNameForSorting = null;
                         switch (order.getProperty()) {
-                            case "이름순":
-                                convertToDatabaseColumnNameForSorting = NAME;
+                            case "Name":
+                                convertToDatabaseColumnNameForSorting = ProfileSortType.Name.getColumnName();
                                 break;
                             default:
-                                convertToDatabaseColumnNameForSorting = DEFAULT_PROFILE_MODIFY_DATE;
+                                convertToDatabaseColumnNameForSorting = ProfileSortType.Newest.getColumnName();
                         }
 
                         Sort.Direction direction = order.getDirection();

--- a/src/main/java/com/swyp3/babpool/domain/profile/domain/ProfileSortType.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/domain/ProfileSortType.java
@@ -1,0 +1,15 @@
+package com.swyp3.babpool.domain.profile.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ProfileSortType {
+
+    Newest("profile_modify_date"),
+    Name("user_name")
+    ;
+
+    private final String columnName;
+}

--- a/src/main/resources/mapper/ProfileMapper.xml
+++ b/src/main/resources/mapper/ProfileMapper.xml
@@ -9,9 +9,7 @@
         <result property="profileImageUrl" column="profile_image_url"/>
         <result property="profileIntro" column="profile_intro"/>
         <result property="profileContents" column="profile_contents"/>
-        <result property="profileActiveFlag" column="profile_active_flag"/>
-        <result property="createdAt" column="created_at"/>
-        <result property="updatedAt" column="updated_at"/>
+        <result property="profileModifyDate" column="profile_modify_date"/>
         <result property="keywordIdWithNameString" column="keyword_info"/>
         <result property="userGrade" column="user_grade"/>
     </resultMap>
@@ -19,10 +17,10 @@
     <select id="findAllByPageable"
             parameterType="com.swyp3.babpool.global.common.request.PagingRequestList"
             resultMap="profilePagingResponse">
-        SELECT profile.*,
-            GROUP_CONCAT(CONCAT(k.keyword_id, ':', k.keyword_name)) AS keyword_info,
-            account.user_grade
-        FROM t_profile profile
+        SELECT profile.profile_id, profile.user_id, profile.profile_image_url, profile.profile_intro, profile.profile_contents,
+               profile.profile_modify_date,
+            GROUP_CONCAT(CONCAT(k.keyword_id, ':', k.keyword_name)) AS keyword_info, account.user_grade
+        FROM t_profile as profile
             inner JOIN t_user_account account ON profile.user_id = account.user_id
             inner JOIN t_m_user_keyword muk ON profile.user_id = muk.user_id
             inner JOIN t_keyword k ON muk.keyword_id = k.keyword_id

--- a/src/main/resources/mapper/ProfileMapper.xml
+++ b/src/main/resources/mapper/ProfileMapper.xml
@@ -28,8 +28,10 @@
             inner JOIN t_keyword k ON muk.keyword_id = k.keyword_id
         <where>
             <if test="condition.search != null and !condition.search.equals('')">
+                (
                 profile.profile_intro LIKE CONCAT('%', #{condition.search}, '%')
                 OR profile.profile_contents LIKE CONCAT('%', #{condition.search}, '%')
+                )
             </if>
             <if test="condition.keywords != null and !condition.keywords.isEmpty()">
                 <foreach collection="condition.keywords" item="keyword" open="AND muk.keyword_id IN (" close=")" separator=",">
@@ -62,8 +64,10 @@
                 ON profile.user_id = muk.user_id
         <where>
             <if test="search != null and !search.equals('')">
+                (
                 profile.profile_intro LIKE CONCAT('%', #{search}, '%')
                 OR profile.profile_contents LIKE CONCAT('%', #{search}, '%')
+                )
             </if>
             <if test="keywords != null and !keywords.isEmpty()">
                 <foreach collection="keywords" item="keyword" open="AND muk.keyword_id IN (" close=")" separator=",">


### PR DESCRIPTION
Resolves #35 #36 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 프로필 리스트 페이징 시, 최근 수정된 프로필 순으로 정렬이 기본 설정이 되도록 수정.
- 페이징 쿼리 수정

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `@SortDefault` 어노테이션을 API 파라미터에 추가.
- ProfileMapper.xml 에서 WHERE 절의 OR 연산을 괄호로 묶어 먼저 수행되도록 쿼리 수정.
- 프로필 수정 일자를 페이징 응답에 포함
- [PagingSortTypeMappingConfig.java](https://github.com/swyp3-babpool/babpool-backend/pull/39/files#diff-09c0491c126ffc85d0f8e3b24f7925debae2ac068379297c651bdc6961d1aeb5) 설정 파일을 만들어 프론트가 데이터베이스 테이블의 컬럼명이 아닌, 특정 정렬 기준 명을 서버로 전달했을 때, 올바르게 컬럼명으로 변환되도록 구현
   - 특정 정렬 기준과 컬럼명 매핑을 위해 `ProfileSortType` Enum 을 추가

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- [Pageable의 sort 값 변경 코드 참고 링크](https://stackoverflow.com/questions/68270814/spring-pageable-sort-change-name-of-property)

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->