### PR TITLE
fix(uuid): Update uui repository add param annotation to specifiy parameter

### DIFF
--- a/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/WebMvcInterceptJwtConfig.java
@@ -13,7 +13,7 @@ public class WebMvcInterceptJwtConfig implements WebMvcConfigurer {
     private final JwtTokenInterceptor jwtTokenInterceptor;
     private static final String[] EXCLUDE_PATHS = {
         "/api/user/sign/in", "/api/user/sign/up", "/api/user/sign/out", "/api/token/access/refresh",
-        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens", "/api/test/image/upload", "/api/test/image/delete", "/api/test/cookie",
+        "/api/test/connection", "/api/test/jwt/permitted", "/api/test/uuid", "/api/test/jwt/tokens", "/api/test/image/upload", "/api/test/image/delete", "/api/test/cookie", "/api/test/from/uuid/to/id",
         "/api/profile/list"
     };
 

--- a/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
+++ b/src/main/java/com/swyp3/babpool/global/uuid/dao/UserUuidRepository.java
@@ -2,13 +2,14 @@ package com.swyp3.babpool.global.uuid.dao;
 
 import com.swyp3.babpool.global.uuid.domain.UserUuid;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
 @Mapper
 public interface UserUuidRepository {
 
-    Optional<UserUuid> findByUserUuIdBytes(byte[] userUuid);
+    Optional<UserUuid> findByUserUuIdBytes(@Param("userUuid") byte[] userUuid);
 
     void save(UserUuid userUuid);
 

--- a/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
+++ b/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
@@ -67,6 +67,11 @@ public class HealthCheckApi {
         return ResponseEntity.ok(String.valueOf(uuidService.createUuid(requestBody.get("userId"))));
     }
 
+    @GetMapping("/api/test/from/uuid/to/id")
+    public ResponseEntity<Long> testGetUserIdByUuid(@RequestParam String userUuid) {
+        return ResponseEntity.ok(uuidService.getUserIdByUuid(userUuid));
+    }
+
     @GetMapping("/api/test/cookie")
     public ApiResponseWithCookie<String> testCookie() {
         return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK, "success", "data", "refreshToken1234");

--- a/src/test/java/com/swyp3/babpool/global/uuid/application/UuidServiceV7Test.java
+++ b/src/test/java/com/swyp3/babpool/global/uuid/application/UuidServiceV7Test.java
@@ -58,5 +58,32 @@ class UuidServiceV7Test {
 
     }
 
+    @Test
+    void getUuidByUserId() {
+        // given
+        Long userId = 1L;
+        UUID createdUuid = uuidServiceV7.createUuid(userId);
+        // when
+        UUID resultUuid = uuidServiceV7.getUuidByUserId(userId);
+        // then
+        log.info("UUID : {}", resultUuid);
+        assertNotNull(resultUuid);
+        Assertions.assertThat(resultUuid).isEqualTo(createdUuid);
+    }
+
+    @Test
+    void getUserIdByUuid() {
+        // given
+        Long userId = 1L;
+        UUID createdUuid = uuidServiceV7.createUuid(userId);
+        log.info("createdUuid : {}", createdUuid);
+        // when
+        Long resultUserId = uuidServiceV7.getUserIdByUuid(createdUuid.toString());
+
+        // then
+        log.info("resultUserId : {}", resultUserId);
+        assertNotNull(resultUserId);
+        Assertions.assertThat(resultUserId).isEqualTo(userId);
+    }
 
 }


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- UuidRepository의 `findByUserUuIdBytes` 메서드 수행 시, `userUuid`가 Mapper 의 매개변수로 바인딩 되지 않음

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `@Param` 어노테이션을 추가해 매개변수 명을 명시.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 해당 어노테이션이 없어도 정상 동작하는 제 환경과 달리, @yeonjookang 님 환경에서는 동작하지 않음.
![image](https://github.com/swyp3-babpool/babpool-backend/assets/128882585/ef266bcc-6beb-40d7-9459-f2ea8e43a75e)
- 위와 같이 xml 파일에 빨간 밑줄과 `unable to resolve table` 메시지가 IDE에 나타나는 것이 정상 동작하지 않은 원인일 가능성이 있음. 더 조사 필요.
- [참고 링크 : 인텔리제이 문의 게시판](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360007103039--Solved-Unable-to-resolve-table-name)
![image](https://github.com/swyp3-babpool/babpool-backend/assets/128882585/73db7c96-7b44-417b-aa2f-4d119f8bc5cd)

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->