### PR TITLE
feat(review, appointment): Add features to resolve #51, appointment history

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
@@ -2,9 +2,7 @@ package com.swyp3.babpool.domain.appointment.api;
 
 import com.swyp3.babpool.domain.appointment.application.AppointmentService;
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentReceiveResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentCreateResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentSendResponse;
+import com.swyp3.babpool.domain.appointment.application.response.*;
 import com.swyp3.babpool.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +41,22 @@ public class AppointmentApi {
     @GetMapping("/api/appointment/list/receive")
     public ApiResponse<List<AppointmentReceiveResponse>> getReceiveAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {
         return ApiResponse.ok(appointmentService.getReceiveAppointmentList(userId));
+    }
+
+    /**
+     * 밥약 히스토리 - 완료(DONE) 리스트 조회 API
+     */
+    @GetMapping("/api/appointment/list/done")
+    public ApiResponse<List<AppointmentHistoryDoneResponse>> getDoneAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {
+        return ApiResponse.ok(appointmentService.getDoneAppointmentList(userId));
+    }
+
+    /**
+     * 밥약 히스토리 - 거절(EXPIRE, REJECT) 리스트 조회 API
+     */
+    @GetMapping("/api/appointment/list/refuse")
+    public ApiResponse<List<AppointmentHistoryRefuseResponse>> getRefuseAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {
+        return ApiResponse.ok(appointmentService.getRefuseAppointmentList(userId));
     }
 
 

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
@@ -1,9 +1,7 @@
 package com.swyp3.babpool.domain.appointment.application;
 
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentReceiveResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentCreateResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentSendResponse;
+import com.swyp3.babpool.domain.appointment.application.response.*;
 
 import java.util.List;
 
@@ -13,4 +11,8 @@ public interface AppointmentService {
     List<AppointmentSendResponse> getSendAppointmentList(Long userId);
 
     List<AppointmentReceiveResponse> getReceiveAppointmentList(Long userId);
+
+    List<AppointmentHistoryDoneResponse> getDoneAppointmentList(Long userId);
+
+    List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long userId);
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -1,15 +1,16 @@
 package com.swyp3.babpool.domain.appointment.application;
 
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentReceiveResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentCreateResponse;
-import com.swyp3.babpool.domain.appointment.application.response.AppointmentSendResponse;
+import com.swyp3.babpool.domain.appointment.application.response.*;
 import com.swyp3.babpool.domain.appointment.dao.AppointmentRepository;
 import com.swyp3.babpool.domain.appointment.domain.Appointment;
 import com.swyp3.babpool.domain.appointment.domain.AppointmentRequestMessage;
 import com.swyp3.babpool.domain.appointment.exception.AppointmentException;
 import com.swyp3.babpool.domain.appointment.exception.eoorcode.AppointmentErrorCode;
 import com.swyp3.babpool.domain.profile.dao.ProfileRepository;
+import com.swyp3.babpool.domain.profile.domain.Profile;
+import com.swyp3.babpool.domain.user.application.UserService;
+import com.swyp3.babpool.domain.user.application.response.MyPageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,7 @@ public class AppointmentServiceImpl implements AppointmentService{
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final AppointmentRepository appointmentRepository;
     private final ProfileRepository profileRepository;
+    private final UserService userService;
     
     @Transactional
     @Override
@@ -64,12 +66,26 @@ public class AppointmentServiceImpl implements AppointmentService{
 
     @Override
     public List<AppointmentSendResponse> getSendAppointmentList(Long userId) {
-        return appointmentRepository.findAppointmentListByRequesterId(userId);
+        return appointmentRepository.findAppointmentListByRequesterId(userId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_SEND_NOT_FOUND, "발신한 밥약이 존재하지 않습니다."));
     }
 
     @Override
     public List<AppointmentReceiveResponse> getReceiveAppointmentList(Long userId) {
-        return appointmentRepository.findAppointmentListByReceiverId(userId);
+        return appointmentRepository.findAppointmentListByReceiverId(userId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_RECEIVE_NOT_FOUND, "수신한 밥약이 존재하지 않습니다."));
+    }
+
+    @Override
+    public List<AppointmentHistoryDoneResponse> getDoneAppointmentList(Long userId) {
+        return appointmentRepository.findDoneAppointmentListByRequesterId(userId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_DONE_NOT_FOUND, "완료된 밥약이 존재하지 않습니다."));
+    }
+
+    @Override
+    public List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long receiverUserId) {
+    return appointmentRepository.findRefuseAppointmentListByReceiverId(receiverUserId)
+                .orElseThrow(() -> new AppointmentException(AppointmentErrorCode.APPOINTMENT_REFUSE_NOT_FOUND, "거절된 밥약이 존재하지 않습니다."));
     }
 
 

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentHistoryDoneResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentHistoryDoneResponse.java
@@ -1,0 +1,32 @@
+package com.swyp3.babpool.domain.appointment.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+public class AppointmentHistoryDoneResponse {
+
+    private Long appointmentId;
+    private Long appointmentReceiverProfileId;
+    private String appointmentReceiverUserNickname;
+    private String appointmentReceiverProfileImageUrl;
+    private String appointmentStatus;
+    private LocalDateTime appointment_fix_date_time;
+    private String reviewRequired;
+
+    @Builder
+    public AppointmentHistoryDoneResponse(Long appointmentId, Long appointmentReceiverProfileId, String appointmentReceiverUserNickname, String appointmentReceiverProfileImageUrl, String appointmentStatus, LocalDateTime appointment_fix_date_time, String reviewRequired) {
+        this.appointmentId = appointmentId;
+        this.appointmentReceiverProfileId = appointmentReceiverProfileId;
+        this.appointmentReceiverUserNickname = appointmentReceiverUserNickname;
+        this.appointmentReceiverProfileImageUrl = appointmentReceiverProfileImageUrl;
+        this.appointmentStatus = appointmentStatus;
+        this.appointment_fix_date_time = appointment_fix_date_time;
+        this.reviewRequired = reviewRequired;
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentHistoryRefuseResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentHistoryRefuseResponse.java
@@ -1,0 +1,31 @@
+package com.swyp3.babpool.domain.appointment.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+public class AppointmentHistoryRefuseResponse {
+
+    private Long appointmentId;
+    private Long appointmentReceiverProfileId;
+    private String appointmentReceiverUserNickname;
+    private String appointmentReceiverProfileImageUrl;
+    private String appointmentStatus;
+    private LocalDateTime refuseCreateDate;
+    private String refuseType;
+
+    @Builder
+    public AppointmentHistoryRefuseResponse(Long appointmentId, Long appointmentReceiverProfileId, String appointmentReceiverUserNickname, String appointmentReceiverProfileImageUrl, String appointmentStatus, LocalDateTime refuseCreateDate, String refuseType) {
+        this.appointmentId = appointmentId;
+        this.appointmentReceiverProfileId = appointmentReceiverProfileId;
+        this.appointmentReceiverUserNickname = appointmentReceiverUserNickname;
+        this.appointmentReceiverProfileImageUrl = appointmentReceiverProfileImageUrl;
+        this.appointmentStatus = appointmentStatus;
+        this.refuseCreateDate = refuseCreateDate;
+        this.refuseType = refuseType;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
@@ -1,21 +1,28 @@
 package com.swyp3.babpool.domain.appointment.dao;
 
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
+import com.swyp3.babpool.domain.appointment.application.response.AppointmentHistoryDoneResponse;
+import com.swyp3.babpool.domain.appointment.application.response.AppointmentHistoryRefuseResponse;
 import com.swyp3.babpool.domain.appointment.application.response.AppointmentReceiveResponse;
 import com.swyp3.babpool.domain.appointment.application.response.AppointmentSendResponse;
 import com.swyp3.babpool.domain.appointment.domain.Appointment;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface AppointmentRepository {
 
     int saveAppointmentInit(AppointmentCreateRequest appointmentCreateRequest);
 
-    List<AppointmentSendResponse> findAppointmentListByRequesterId(Long requesterUserId);
+    Optional<List<AppointmentSendResponse>> findAppointmentListByRequesterId(Long requesterUserId);
 
-    List<AppointmentReceiveResponse> findAppointmentListByReceiverId(Long receiverUserId);
+    Optional<List<AppointmentReceiveResponse>> findAppointmentListByReceiverId(Long receiverUserId);
 
     Appointment findByAppointmentId(Long appointmentId);
+
+    Optional<List<AppointmentHistoryDoneResponse>> findDoneAppointmentListByRequesterId(Long requesterUserId);
+
+    Optional<List<AppointmentHistoryRefuseResponse>> findRefuseAppointmentListByReceiverId(Long receiverUserId);
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/exception/eoorcode/AppointmentErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/exception/eoorcode/AppointmentErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AppointmentErrorCode implements CustomErrorCode {
 
-    DUPLICATE_APPOINTMENT_REQUEST(HttpStatus.BAD_REQUEST, "이미 예약된 시간대가 존재합니다.")
-
+    DUPLICATE_APPOINTMENT_REQUEST(HttpStatus.BAD_REQUEST, "이미 예약된 시간대가 존재합니다."),
+    APPOINTMENT_SEND_NOT_FOUND(HttpStatus.NOT_FOUND, "발신한 밥약이 존재하지 않습니다."),
+    APPOINTMENT_RECEIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "수신한 밥약이 존재하지 않습니다."),
+    APPOINTMENT_DONE_NOT_FOUND(HttpStatus.NOT_FOUND, "완료한 밥약이 존재하지 않습니다."),
+    APPOINTMENT_REFUSE_NOT_FOUND(HttpStatus.NOT_FOUND, "거절된 밥약이 존재하지 않습니다."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/config/PagingSortTypeMappingConfig.java
@@ -34,13 +34,17 @@ public class PagingSortTypeMappingConfig implements WebMvcConfigurer {
 
                 if (currentSort != null && !currentSort.isEmpty()) {
                     for (Sort.Order order : currentSort) {
-                        String convertToDatabaseColumnNameForSorting = null;
+                        String convertToDatabaseColumnNameForSorting = order.getProperty();
                         switch (order.getProperty()) {
-                            case "Name":
-                                convertToDatabaseColumnNameForSorting = ProfileSortType.Name.getColumnName();
+                            case "NickName":
+                                convertToDatabaseColumnNameForSorting = ProfileSortType.NickName.getColumnName();
                                 break;
-                            default:
-                                convertToDatabaseColumnNameForSorting = ProfileSortType.Newest.getColumnName();
+                            case "NewestPofile":
+                                convertToDatabaseColumnNameForSorting = ProfileSortType.NewestPofile.getColumnName();
+                                break;
+                            case "NewestReview":
+                                convertToDatabaseColumnNameForSorting = ProfileSortType.NewestReview.getColumnName();
+                                break;
                         }
 
                         Sort.Direction direction = order.getDirection();

--- a/src/main/java/com/swyp3/babpool/domain/profile/domain/ProfileSortType.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/domain/ProfileSortType.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @Getter
 public enum ProfileSortType {
 
-    Newest("profile_modify_date"),
-    Name("user_nick_name")
+    NewestPofile("profile_modify_date"),
+    NickName("user_nick_name"),
+    NewestReview("review_create_date")
     ;
 
     private final String columnName;

--- a/src/main/java/com/swyp3/babpool/domain/review/api/ReviewApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/api/ReviewApi.java
@@ -1,0 +1,76 @@
+package com.swyp3.babpool.domain.review.api;
+
+import com.swyp3.babpool.domain.review.application.response.ReviewPagingResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewSaveResponse;
+import com.swyp3.babpool.domain.review.api.request.ReviewUpdateRequest;
+import com.swyp3.babpool.domain.review.api.request.ReviewCreateRequest;
+import com.swyp3.babpool.domain.review.application.ReviewService;
+import com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse;
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+public class ReviewApi {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 특정 프로필이 받은 모든 리뷰 조회
+     */
+    @GetMapping("/api/review/list")
+    public ApiResponse<Page<ReviewPagingResponse>> getReviewListPaging(
+            @RequestParam("profileId") Long profileId,
+            @PageableDefault(size = 10)
+            @SortDefault(sort = "review_create_date", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(reviewService.getReviewList(profileId, pageable));
+    }
+
+
+    /**
+     * 특정 프로필의 리뷰 타입별 개수 조회
+     * @param profileId
+     * @return
+     */
+    @GetMapping("/api/review/{profileId}/count")
+    public ApiResponse<ReviewCountByTypeResponse> getReviewCountByType(@PathVariable("profileId") Long profileId) {
+        return ApiResponse.ok(reviewService.getReviewCountByType(profileId));
+    }
+
+    /**
+     * 신규 리뷰 작성
+     * @param request
+     * @return
+     */
+    @PostMapping("/api/review/create")
+    public ApiResponse<ReviewSaveResponse> createReview(@RequestAttribute(value = "userId") Long userId,
+                                                          @RequestBody ReviewCreateRequest request) {
+        return ApiResponse.ok(reviewService.createReview(request.setReviewerUserId(userId)));
+    }
+
+    /**
+     * 리뷰 상세 조회
+     */
+    @GetMapping("/api/review/{appointmentId}")
+    public ApiResponse<ReviewSaveResponse> getReview(@PathVariable("appointmentId") Long appointmentId) {
+        return ApiResponse.ok(reviewService.getReviewInfo(appointmentId));
+    }
+
+    /**
+     * 리뷰 수정
+     * @param request
+     * @return
+     */
+    @PutMapping("/api/review/update")
+    public ApiResponse<ReviewSaveResponse> updateReview(@RequestAttribute(value = "userId") Long userId,
+                                                          @RequestBody ReviewUpdateRequest request) {
+        return ApiResponse.ok(reviewService.updateReview(request.setReviewerUserId(userId)));
+    }
+
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/api/request/ReviewCreateRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/api/request/ReviewCreateRequest.java
@@ -1,0 +1,32 @@
+package com.swyp3.babpool.domain.review.api.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ReviewCreateRequest {
+
+    private Long reviewId;
+    private Long reviewerUserId;
+    private Long targetAppointmentId;
+    private String rateType;
+    private String reviewContent;
+
+    @Builder
+    public ReviewCreateRequest(Long reviewId, Long reviewerUserId, Long targetAppointmentId, String rateType, String reviewContent) {
+        this.reviewId = reviewId;
+        this.reviewerUserId = reviewerUserId;
+        this.targetAppointmentId = targetAppointmentId;
+        this.rateType = rateType;
+        this.reviewContent = reviewContent;
+    }
+
+    public ReviewCreateRequest setReviewerUserId(Long reviewerUserId) {
+        this.reviewerUserId = reviewerUserId;
+        return this;
+    }
+
+
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/api/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/api/request/ReviewUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.swyp3.babpool.domain.review.api.request;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ReviewUpdateRequest {
+
+    private Long reviewId;
+    private Long reviewerUserId;
+    private Long targetAppointmentId;
+    private String rateType;
+    private String reviewContent;
+
+    public ReviewUpdateRequest(Long reviewId, Long reviewerUserId, Long targetAppointmentId, String rateType, String reviewContent) {
+        this.reviewId = reviewId;
+        this.reviewerUserId = reviewerUserId;
+        this.targetAppointmentId = targetAppointmentId;
+        this.rateType = rateType;
+        this.reviewContent = reviewContent;
+    }
+
+    public ReviewUpdateRequest setReviewerUserId(Long reviewerUserId) {
+        this.reviewerUserId = reviewerUserId;
+        return this;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/application/ReviewService.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/application/ReviewService.java
@@ -1,0 +1,21 @@
+package com.swyp3.babpool.domain.review.application;
+
+import com.swyp3.babpool.domain.review.api.request.ReviewCreateRequest;
+import com.swyp3.babpool.domain.review.api.request.ReviewUpdateRequest;
+import com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewPagingResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewSaveResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewService {
+    ReviewCountByTypeResponse getReviewCountByType(Long profileId);
+
+    ReviewSaveResponse createReview(ReviewCreateRequest request);
+
+    ReviewSaveResponse updateReview(ReviewUpdateRequest reviewCreateRequest);
+
+    ReviewSaveResponse getReviewInfo(Long appointmentId);
+
+    Page<ReviewPagingResponse> getReviewList(Long profileId, Pageable pageable);
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/application/ReviewServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/application/ReviewServiceImpl.java
@@ -1,0 +1,110 @@
+package com.swyp3.babpool.domain.review.application;
+
+import com.swyp3.babpool.domain.appointment.dao.AppointmentRepository;
+import com.swyp3.babpool.domain.appointment.domain.Appointment;
+import com.swyp3.babpool.domain.review.api.request.ReviewCreateRequest;
+import com.swyp3.babpool.domain.review.api.request.ReviewUpdateRequest;
+import com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewPagingResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewSaveResponse;
+import com.swyp3.babpool.domain.review.dao.ReviewRepository;
+import com.swyp3.babpool.domain.review.exception.ReviewErrorCode;
+import com.swyp3.babpool.domain.review.exception.ReviewException;
+import com.swyp3.babpool.global.common.request.PagingRequestList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReviewServiceImpl implements ReviewService{
+
+    private final ReviewRepository reviewRepository;
+    private final AppointmentRepository appointmentRepository;
+
+    @Override
+    public ReviewCountByTypeResponse getReviewCountByType(Long profileId) {
+        return reviewRepository.countReviewByType(profileId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.NOT_FOUND_REVIEW,"요청된 프로필에 리뷰가 존재하지 않습니다."));
+    }
+
+    @Override
+    public ReviewSaveResponse createReview(ReviewCreateRequest reviewCreateRequest) {
+        validateIsSameAppointmentRequest(reviewCreateRequest.getTargetAppointmentId(), reviewCreateRequest.getReviewerUserId());
+
+        reviewRepository.findByAppointmentId(reviewCreateRequest.getTargetAppointmentId()).ifPresent(review -> {
+            throw new ReviewException(ReviewErrorCode.ALREADY_EXIST_REVIEW,"잘못된 요청. 이미 리뷰가 존재합니다.");
+        });
+
+        // 리뷰 작성 가능 시간 체크
+        if(!reviewRepository.isReviewCreateAvailableTime(reviewCreateRequest.getTargetAppointmentId())){
+            throw new ReviewException(ReviewErrorCode.REVIEW_CREATE_REQUEST_FAIL,"리뷰 작성 가능 시간이 아닙니다.");
+        }
+
+        reviewRepository.saveReview(reviewCreateRequest)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_CREATE_REQUEST_FAIL,"리뷰 작성에 실패하였습니다."));
+
+        return ReviewSaveResponse.of(reviewRepository.findByReviewId(reviewCreateRequest.getReviewId()).orElseThrow(
+                () -> new ReviewException(ReviewErrorCode.NOT_FOUND_REVIEW,"리뷰 정보를 찾을 수 없습니다.")
+        ));
+    }
+
+    @Override
+    public ReviewSaveResponse updateReview(ReviewUpdateRequest reviewUpdateRequest) {
+        validateIsSameAppointmentRequest(reviewUpdateRequest.getTargetAppointmentId(), reviewUpdateRequest.getReviewerUserId());
+
+        // 리뷰 수정 가능 시간 체크
+        if(!reviewRepository.isReviewUpdateAvailableTime(reviewUpdateRequest.getTargetAppointmentId())){
+            throw new ReviewException(ReviewErrorCode.REVIEW_UPDATE_REQUEST_FAIL,"리뷰 수정 가능 시간이 아닙니다.");
+        }
+
+        reviewRepository.updateReview(reviewUpdateRequest)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_UPDATE_REQUEST_FAIL,"리뷰 수정에 실패하였습니다."));
+
+        return ReviewSaveResponse.of(reviewRepository.findByReviewId(reviewUpdateRequest.getReviewId()).orElseThrow(
+                () -> new ReviewException(ReviewErrorCode.NOT_FOUND_REVIEW,"리뷰 정보를 찾을 수 없습니다.")
+        ));
+    }
+
+    /**
+     * request의 targetAppointmentId 으로 조회한 약속의 appointment_request_id 와 일치하는지 확인
+     * @param targetAppointmentId
+     * @param reviewerUserId
+     */
+    private void validateIsSameAppointmentRequest(Long targetAppointmentId, Long reviewerUserId) {
+        Appointment targetAppointment = appointmentRepository.findByAppointmentId(targetAppointmentId);
+        if(targetAppointment.getAppointmentRequesterUserId() != reviewerUserId){
+            throw new ReviewException(ReviewErrorCode.NOT_VALID_REVIEW_REQUEST,"appointment_request_id 와 리뷰 요청자가 일치하지 않습니다.");
+        }
+    }
+
+    @Override
+    public ReviewSaveResponse getReviewInfo(Long appointmentId) {
+        return null;
+    }
+
+    @Override
+    public Page<ReviewPagingResponse> getReviewList(Long profileId, Pageable pageable) {
+        PagingRequestList<?> pagingRequest = PagingRequestList.builder()
+                .condition(profileId)
+                .pageable(pageable)
+                .build();
+        List<ReviewPagingResponse> reviewPagingResponse = null;
+        int counts = 0;
+        try {
+            reviewPagingResponse = reviewRepository.findAllByPageable(pagingRequest);
+            counts = reviewRepository.countByPageable(profileId);
+        } catch (Exception e) {
+            log.error("리뷰 리스트 조회 중 오류 발생. {}", e.getMessage());
+            log.error("{}", e.getStackTrace());
+            throw new ReviewException(ReviewErrorCode.REVIEW_LIST_ERROR, "리뷰 리스트 조회 중 오류가 발생했습니다.");
+        }
+        return new PageImpl<>(reviewPagingResponse, pageable, counts);
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewCountByTypeResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewCountByTypeResponse.java
@@ -1,0 +1,21 @@
+package com.swyp3.babpool.domain.review.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ReviewCountByTypeResponse {
+
+    private final Long bestCount;
+    private final Long greatCount;
+    private final Long badCount;
+
+    @Builder
+    public ReviewCountByTypeResponse(Long bestCount, Long greatCount, Long badCount) {
+        this.bestCount = bestCount;
+        this.greatCount = greatCount;
+        this.badCount = badCount;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewPagingResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewPagingResponse.java
@@ -1,0 +1,27 @@
+package com.swyp3.babpool.domain.review.application.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+public class ReviewPagingResponse {
+
+    private Long reviewId;
+    private Long appointmentId;
+    private String reviewRate;
+    private String reviewComment;
+    private LocalDateTime reviewCreateDate;
+
+    @Builder
+    public ReviewPagingResponse(Long reviewId, Long appointmentId, String reviewRate, String reviewComment, LocalDateTime reviewCreateDate) {
+        this.reviewId = reviewId;
+        this.appointmentId = appointmentId;
+        this.reviewRate = reviewRate;
+        this.reviewComment = reviewComment;
+        this.reviewCreateDate = reviewCreateDate;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewSaveResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/application/response/ReviewSaveResponse.java
@@ -1,0 +1,33 @@
+package com.swyp3.babpool.domain.review.application.response;
+
+import com.swyp3.babpool.domain.review.domain.Review;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class ReviewSaveResponse {
+
+    private Long reviewId;
+    private Long appointmentId;
+    private String reviewRate;
+    private String reviewComment;
+
+    @Builder
+    public ReviewSaveResponse(Long reviewId, Long appointmentId, String reviewRate, String reviewComment) {
+        this.reviewId = reviewId;
+        this.appointmentId = appointmentId;
+        this.reviewRate = reviewRate;
+        this.reviewComment = reviewComment;
+    }
+
+    public static ReviewSaveResponse of(Review review) {
+        return ReviewSaveResponse.builder()
+                .reviewId(review.getReviewId())
+                .appointmentId(review.getAppointmentId())
+                .reviewRate(review.getReviewRate())
+                .reviewComment(review.getReviewComment())
+                .build();
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/dao/ReviewRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/dao/ReviewRepository.java
@@ -1,0 +1,34 @@
+package com.swyp3.babpool.domain.review.dao;
+
+import com.swyp3.babpool.domain.review.api.request.ReviewCreateRequest;
+import com.swyp3.babpool.domain.review.api.request.ReviewUpdateRequest;
+import com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewPagingResponse;
+import com.swyp3.babpool.domain.review.application.response.ReviewSaveResponse;
+import com.swyp3.babpool.domain.review.domain.Review;
+import com.swyp3.babpool.global.common.request.PagingRequestList;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface ReviewRepository {
+    Optional<ReviewCountByTypeResponse> countReviewByType(Long profileId);
+
+    Optional<Object> findByAppointmentId(Long targetAppointmentId);
+
+    Optional<Review> findByReviewId(Long reviewId);
+
+    Optional<ReviewSaveResponse> saveReview(ReviewCreateRequest reviewCreateRequest);
+
+    Optional<ReviewSaveResponse> updateReview(ReviewUpdateRequest reviewUpdateRequest);
+
+    boolean isReviewCreateAvailableTime(Long targetAppointmentId);
+
+    boolean isReviewUpdateAvailableTime(Long targetAppointmentId);
+
+    List<ReviewPagingResponse> findAllByPageable(PagingRequestList<?> pagingRequest);
+
+    int countByPageable(Long profileId);
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/domain/Review.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/domain/Review.java
@@ -1,0 +1,31 @@
+package com.swyp3.babpool.domain.review.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+public class Review {
+
+    private Long reviewId;
+    private Long appointmentId;
+    private String reviewRate;
+    private String reviewComment;
+    private Boolean reviewDeleteFlag;
+    private LocalDateTime reviewCreateDate;
+    private LocalDateTime reviewModifyDate;
+
+    @Builder
+    public Review(Long reviewId, Long appointmentId, String reviewRate, String reviewComment, Boolean reviewDeleteFlag, LocalDateTime reviewCreateDate, LocalDateTime reviewModifyDate) {
+        this.reviewId = reviewId;
+        this.appointmentId = appointmentId;
+        this.reviewRate = reviewRate;
+        this.reviewComment = reviewComment;
+        this.reviewDeleteFlag = reviewDeleteFlag;
+        this.reviewCreateDate = reviewCreateDate;
+        this.reviewModifyDate = reviewModifyDate;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewErrorCode.java
@@ -1,0 +1,15 @@
+package com.swyp3.babpool.domain.review.exception;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements CustomErrorCode {
+
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewErrorCode.java
@@ -9,6 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements CustomErrorCode {
 
+    NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "There is no review for the requested profile."),
+    NOT_VALID_REVIEW_REQUEST(HttpStatus.BAD_REQUEST, "Not valid review request."),
+    REVIEW_CREATE_REQUEST_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to create review."),
+    REVIEW_UPDATE_REQUEST_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update review."),
+    ALREADY_EXIST_REVIEW(HttpStatus.BAD_REQUEST, "Review already exists."),
+    REVIEW_LIST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred while retrieving the review list."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewException.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewException.java
@@ -1,0 +1,12 @@
+package com.swyp3.babpool.domain.review.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReviewException extends RuntimeException{
+
+    private final ReviewErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/domain/review/exception/ReviewExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.swyp3.babpool.domain.review.exception;
+
+import com.swyp3.babpool.global.common.response.ApiErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ReviewExceptionHandler {
+
+    @ExceptionHandler
+    protected ApiErrorResponse handleReviewException(ReviewException exception){
+        log.error("ReviewException getReviewErrorCode() >> "+exception.getErrorCode());
+        log.error("ReviewException getMessage() >> "+exception.getMessage());
+        return ApiErrorResponse.of(exception.getErrorCode());
+    }
+}

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -23,6 +23,17 @@
         <result property="appointmentFixDateTime" column="appointment_fix_date_time"/>
     </resultMap>
 
+    <resultMap id="appointmentHistoryRefuseResponse" type="com.swyp3.babpool.domain.appointment.application.response.AppointmentHistoryRefuseResponse">
+        <id property="appointmentId" column="appointment_id"/>
+        <result property="appointmentReceiverProfileId" column="profile_id"/>
+        <result property="appointmentReceiverUserNickname" column="user_nick_name"/>
+        <result property="appointmentReceiverProfileImageUrl" column="profile_image_url"/>
+        <result property="appointmentStatus" column="appointment_status"/>
+        <result property="refuseCreateDate" column="refuse_create_date"/>
+        <result property="refuseType" column="refuse_type"/>
+    </resultMap>
+
+    <!--  밥약 알림 - 특정 사용자가 보낸 밥약 알림  -->
     <select id="findAppointmentListByRequesterId" resultMap="appointmentSendResponse" parameterType="long">
         SELECT
             appoint.appointment_id,
@@ -31,7 +42,7 @@
             profile.profile_image_url,
             appoint.appointment_status,
             appoint.appointment_create_date,
-            IF(appoint.appointment_status = 'ACCEPT',
+            IF(appoint.appointment_status = 'ACCEPT' OR appoint.appointment_status = 'DONE',
                DATE_FORMAT(CONCAT(pdate.possible_date, ' ', ptime.possible_time_start), '%Y-%m-%d %H:%i:%s'),
                NULL
             ) AS appointment_fix_date_time
@@ -41,9 +52,11 @@
             LEFT JOIN t_possible_time ptime ON ptime.possible_time_id = appoint.possible_time_id
             LEFT JOIN t_possible_date pdate ON pdate.possible_date_id = ptime.possible_date_id
         WHERE
-            appoint.appointment_requester_id =1; #{requesterUserId}
+            appoint.appointment_requester_id = #{requesterUserId}
+        AND appoint.appointment_status IN ('WAITING', 'ACCEPT')
     </select>
 
+    <!--  밥약 알림 - 특정 사용자가 받은 밥약 알림  -->
     <select id="findAppointmentListByReceiverId" resultMap="appointmentReceiveResponse" parameterType="long">
         SELECT
             appoint.appointment_id,
@@ -52,7 +65,7 @@
             profile.profile_image_url,
             appoint.appointment_status,
             appoint.appointment_create_date,
-            IF(appoint.appointment_status = 'ACCEPT',
+            IF(appoint.appointment_status = 'ACCEPT' OR appoint.appointment_status = 'DONE',
                DATE_FORMAT(CONCAT(pdate.possible_date, ' ', ptime.possible_time_start), '%Y-%m-%d %H:%i:%s'),
                NULL
             ) AS appointment_fix_date_time
@@ -63,6 +76,7 @@
             LEFT JOIN t_possible_date pdate ON pdate.possible_date_id = ptime.possible_date_id
         WHERE
             appoint.appointment_receiver_id = #{receiverUserId}
+        AND appoint.appointment_status IN ('WAITING', 'ACCEPT')
     </select>
 
     <select id="findUserIdByProfileId" resultType="long" parameterType="long">
@@ -100,6 +114,46 @@
         WHERE
             appointment_id = #{appointmentId}
     </select>
+
+    <!--  밥약 히스토리 - 완료된 요청 리스트  -->
+    <select id="findDoneAppointmentListByRequesterId" resultMap="appointmentSendResponse" parameterType="long">
+        SELECT
+            appoint.appointment_id,
+            profile.profile_id,
+            account.user_nick_name,
+            profile.profile_image_url,
+            appoint.appointment_status,
+            DATE_FORMAT(CONCAT(pdate.possible_date, ' ', ptime.possible_time_start), '%Y-%m-%d %H:%i:%s') as appointment_fix_date_time,
+            IF(review.review_id is NULL AND DATE_ADD(DATE_FORMAT(CONCAT(pdate.possible_date, ' ', ptime.possible_time_start), '%Y-%m-%d %H:%i:%s'), INTERVAL 3 DAY) > NOW(), 'REVIEW_REQUIRED', 'REVIEW_NOT_REQUIRED') AS review_require
+        FROM t_appointment appoint
+                 INNER JOIN t_profile profile ON appoint.appointment_receiver_id = profile.user_id
+                 INNER JOIN t_user_account account ON appoint.appointment_receiver_id = account.user_id
+                 LEFT JOIN t_possible_time ptime ON ptime.possible_time_id = appoint.possible_time_id
+                 LEFT JOIN t_possible_date pdate ON pdate.possible_date_id = ptime.possible_date_id
+                 LEFT JOIN t_review review ON appoint.appointment_id = review.appointment_id
+        WHERE
+            appoint.appointment_requester_id = #{requesterUserId}
+          AND appoint.appointment_status = 'DONE';
+    </select>
+
+    <!--  밥약 히스토리 - 거절 당한 요청 리스트  -->
+    <select id="findRefuseAppointmentListByReceiverId" resultMap="appointmentHistoryRefuseResponse">
+        select appoint.appointment_id,
+               profile.profile_id,
+               account.user_nick_name,
+               profile.profile_image_url,
+               appoint.appointment_status,
+               refuse.refuse_create_date,
+               refuse.refuse_type
+        from t_appointment appoint
+                inner join t_profile profile on appoint.appointment_requester_id = profile.user_id
+                inner join t_user_account account on appoint.appointment_requester_id = account.user_id
+                inner join t_refuse refuse on appoint.appointment_id = refuse.appointment_id
+          where appoint.appointment_requester_id = #{receiverUserId}
+             and appoint.appointment_status IN ('REFUSE', 'EXPIRE')
+    </select>
+
+    <!-- ######################################## INSERT ######################################## -->
 
     <insert id="saveAppointmentInit" parameterType="com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest"
             useGeneratedKeys="true" keyProperty="appointmentId">

--- a/src/main/resources/mapper/ReviewMapper.xml
+++ b/src/main/resources/mapper/ReviewMapper.xml
@@ -80,7 +80,7 @@
         LIMIT #{pageable.pageSize} OFFSET #{pageable.offset}
     </select>
 
-    <select id="countByPageable" parameterType="com.swyp3.babpool.domain.review.api.request.ReviewPagingConditions"
+    <select id="countByPageable" parameterType="long"
             resultType="java.lang.Integer">
         SELECT
             COUNT(DISTINCT review_id)

--- a/src/main/resources/mapper/ReviewMapper.xml
+++ b/src/main/resources/mapper/ReviewMapper.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.domain.review.dao.ReviewRepository">
+
+    <select id="countReviewByType" resultType="com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse"
+            parameterType="long">
+        SELECT
+            COUNT(CASE WHEN review_rate = 'BEST' THEN 1 END) AS bestCount,
+            COUNT(CASE WHEN review_rate = 'GREAT' THEN 1 END) AS goodCount,
+            COUNT(CASE WHEN review_rate = 'BAD' THEN 1 END) AS badCount
+        FROM t_review
+        WHERE appointment_id IN (
+            SELECT appointment_id FROM t_appointment
+            WHERE appointment_receiver_id = (
+                SELECT user_id FROM t_profile
+                WHERE profile_id = #{profileId}
+            ) AND appointment_status = 'DONE'
+        );
+    </select>
+
+    <select id="isReviewCreateAvailableTime" resultType="Boolean">
+        SELECT
+            CASE
+                WHEN DATE_ADD(DATE_FORMAT(CONCAT(pdate.possible_date, ' ', ptime.possible_time_start), '%Y-%m-%d %H:%i:%s'), INTERVAL 3 DAY) > NOW()
+                THEN 1 ELSE 0
+            END AS result
+        FROM t_appointment
+            INNER JOIN t_possible_time ptime ON ptime.possible_time_id = t_appointment.possible_time_id
+            INNER JOIN t_possible_date pdate ON pdate.possible_date_id = ptime.possible_date_id
+        WHERE appointment_id = #{appointmentId};
+    </select>
+
+    <select id="isReviewUpdateAvailableTime" resultType="Boolean">
+        SELECT
+            CASE
+                WHEN DATE_ADD(review_create_date), INTERVAL 1 DAY) > NOW()
+                THEN 1 ELSE 0
+            END AS result
+        FROM t_review
+        WHERE review_id = #{reviewId};
+    </select>
+
+    <select id="findByReviewId" resultType="com.swyp3.babpool.domain.review.domain.Review">
+        SELECT
+            review_id,
+            appointment_id,
+            review_rate,
+            review_comment,
+            review_create_date,
+            review_modify_date
+        FROM t_review
+        WHERE review_id = #{reviewId};
+    </select>
+
+    <select id="findAllByPageable" parameterType="com.swyp3.babpool.global.common.request.PagingRequestList"
+            resultType="com.swyp3.babpool.domain.review.application.response.ReviewPagingResponse">
+        SELECT
+            review_id,
+            appointment_id,
+            review_rate,
+            review_comment,
+            review_create_date
+        FROM t_review
+        WHERE appointment_id IN (
+            SELECT appointment_id FROM t_appointment
+            WHERE appointment_receiver_id = (
+                SELECT user_id FROM t_profile
+                WHERE profile_id = #{profileId}
+            ) AND appointment_status = 'DONE'
+        )
+        AND review_delete_flag = 0
+        GROUP BY review_id
+        <if test="pageable.sort != null and !pageable.sort.isEmpty()">
+            ORDER BY
+            <foreach collection="pageable.sort" item="order" separator=",">
+                ${order.property} ${order.direction}
+            </foreach>
+        </if>
+        LIMIT #{pageable.pageSize} OFFSET #{pageable.offset}
+    </select>
+
+    <select id="countByPageable" parameterType="com.swyp3.babpool.domain.review.api.request.ReviewPagingConditions"
+            resultType="java.lang.Integer">
+        SELECT
+            COUNT(DISTINCT review_id)
+        FROM t_review
+        WHERE appointment_id IN (
+            SELECT appointment_id FROM t_appointment
+            WHERE appointment_receiver_id = (
+                SELECT user_id FROM t_profile
+                WHERE profile_id = #{profileId}
+            ) AND appointment_status = 'DONE'
+        )
+        AND review_delete_flag = 0;
+    </select>
+
+    <insert id="saveReview" parameterType="com.swyp3.babpool.domain.review.api.request.ReviewCreateRequest"
+            useGeneratedKeys="true" keyProperty="reviewId">
+        INSERT INTO t_review (appointment_id, review_rate, review_comment, review_delete_flag, review_create_date, review_modify_date)
+        VALUES (
+            #{appointmentId},
+            #{rateType},
+            #{reviewContent},
+            0,
+            NOW(),
+            NOW()
+        );
+    </insert>
+
+    <update id="updateReview" parameterType="com.swyp3.babpool.domain.review.api.request.ReviewUpdateRequest">
+        UPDATE t_review
+        SET review_rate = #{rateType},
+            review_comment = #{reviewContent},
+            review_modify_date = NOW()
+        WHERE review_id = #{reviewId};
+    </update>
+
+
+</mapper>


### PR DESCRIPTION
Resolves #51  
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 리뷰 도메인 기능 구현 및 밥약 히스토리 기능 구현

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
밥약 히스토리 API 추가
- `/api/appointment/list/done` : 완료된 밥약 히스토리 조회
   - `reviewRequired` 필드를 통해 리뷰가 필요한 히스토리를 분류할 수 있습니다.
- `/api/appointment/list/refuse`: 거절(시간만료 및 사용자 거절)된 밥약 히스토리 조회
   - `refuseType` 필드를 통해 거절 사유(시간만료/사용자 거절)를 분류할 수 있습니다.

[AppointmentServiceImpl.java](https://github.com/swyp3-babpool/babpool-backend/pull/55/files#diff-b241852ec1439106c30757165de244bf248d7f92e7f2c547afb9158a15d6a69a)
- 조회된 밥약 히스토리가 없는 경우 에러 응답을 반환하도록 구현했습니다.

리뷰 API 추가
- `/api/review/list` : 특정 프로필이 받은 모든 리뷰를 조회할 수 있습니다.
- `/api/review/{profileId}/count` : 특정 프로필이 받은 리뷰 종류별 개수를 조회할 수 있습니다.
- `/api/review/create` : 새로운 리뷰 작성을 요청합니다.
- `/api/review/{appointmentId}` : 특정 리뷰에 대한 상세 정보를 조회합니다.
- `/api/review/update` : 작성한 리뷰 수정을 요청합니다.

[PagingSortTypeMappingConfig.java](https://github.com/swyp3-babpool/babpool-backend/pull/55/files#diff-09c0491c126ffc85d0f8e3b24f7925debae2ac068379297c651bdc6961d1aeb5)
- Review 도메인에서도 페이징 요청 인터셉터를 사용하게 됨으로써 정렬 기준을 보다 세분화 했습니다.

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->