### PR TITLE
Feat: refuse appointment

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
@@ -1,9 +1,11 @@
 package com.swyp3.babpool.domain.appointment.api;
 
+import com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest;
 import com.swyp3.babpool.domain.appointment.application.AppointmentService;
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
 import com.swyp3.babpool.domain.appointment.application.response.*;
 import com.swyp3.babpool.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -68,5 +70,12 @@ public class AppointmentApi {
         return ApiResponse.ok(appointmentService.getAppointmentPossibleDateTime(profileId));
     }
 
-
+    /**
+     * 밥약 요청 거절 API
+     */
+    @PostMapping("/api/appointment/refuse")
+    public ApiResponse<AppointmentRefuseResponse> refuseAppointment(@RequestAttribute(value = "userId", required = false) Long userId,
+                                                                    @RequestBody @Valid AppointmentRefuseRequest appointmentRefuseRequest) {
+        return ApiResponse.ok(appointmentService.refuseAppointment(appointmentRefuseRequest));
+    }
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/request/AppointmentRefuseRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/request/AppointmentRefuseRequest.java
@@ -11,5 +11,4 @@ public class AppointmentRefuseRequest {
     private Long appointmentId;
     private String refuseType = "RECEIVER";
     private String refuseMessage;
-    private LocalDateTime modifyDate = LocalDateTime.now();
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/request/AppointmentRefuseRequest.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/request/AppointmentRefuseRequest.java
@@ -1,0 +1,15 @@
+package com.swyp3.babpool.domain.appointment.api.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AppointmentRefuseRequest {
+    @NotNull(message = "appointmentId는 필수 값입니다.")
+    private Long appointmentId;
+    private String refuseType = "RECEIVER";
+    private String refuseMessage;
+    private LocalDateTime modifyDate = LocalDateTime.now();
+}

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
@@ -1,6 +1,7 @@
 package com.swyp3.babpool.domain.appointment.application;
 
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
+import com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest;
 import com.swyp3.babpool.domain.appointment.application.response.*;
 
 import java.util.List;
@@ -17,4 +18,6 @@ public interface AppointmentService {
     List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long userId);
 
     List<AppointmentPossibleDateTimeResponse> getAppointmentPossibleDateTime(Long profileId);
+
+    AppointmentRefuseResponse refuseAppointment(AppointmentRefuseRequest appointmentRefuseRequest);
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -5,6 +5,7 @@ import com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest
 import com.swyp3.babpool.domain.appointment.application.response.*;
 import com.swyp3.babpool.domain.appointment.dao.AppointmentRepository;
 import com.swyp3.babpool.domain.appointment.domain.Appointment;
+import com.swyp3.babpool.domain.appointment.domain.AppointmentRefuseMessage;
 import com.swyp3.babpool.domain.appointment.domain.AppointmentRequestMessage;
 import com.swyp3.babpool.domain.appointment.exception.AppointmentException;
 import com.swyp3.babpool.domain.appointment.exception.eoorcode.AppointmentErrorCode;
@@ -130,9 +131,9 @@ public class AppointmentServiceImpl implements AppointmentService{
         Long requesterProfileId = profileRepository.findByUserId(requesterUserId).getProfileId();
 
         simpMessagingTemplate.convertAndSend("/topic/appointment/" + requesterProfileId,
-                AppointmentRequestMessage.builder()
-                        .targetProfileId(requesterProfileId)
-                        .message(HttpStatus.OK.name())
+                AppointmentRefuseMessage.builder()
+                        .requestProfileId(requesterProfileId)
+                        .refuseMessage(HttpStatus.OK.name())
                         .build());
         return new AppointmentRefuseResponse("밥약 거절이 처리되었습니다.");
     }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentRefuseResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/response/AppointmentRefuseResponse.java
@@ -1,0 +1,10 @@
+package com.swyp3.babpool.domain.appointment.application.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AppointmentRefuseResponse {
+    private String okMessage;
+}

--- a/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
@@ -1,6 +1,7 @@
 package com.swyp3.babpool.domain.appointment.dao;
 
 import com.swyp3.babpool.domain.appointment.api.request.AppointmentCreateRequest;
+import com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest;
 import com.swyp3.babpool.domain.appointment.application.response.*;
 import com.swyp3.babpool.domain.appointment.domain.Appointment;
 import org.apache.ibatis.annotations.Mapper;
@@ -38,4 +39,8 @@ public interface AppointmentRepository {
     int saveAppointmentRequest(AppointmentCreateRequest appointmentCreateRequest);
 
     int saveAppointmentRequestTime(AppointmentCreateRequest appointmentCreateRequest);
+
+    void updateAppointmentReject(AppointmentRefuseRequest appointmentRefuseRequest);
+
+    void saveRefuseData(AppointmentRefuseRequest appointmentRefuseRequest);
 }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/domain/AppointmentRefuseMessage.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/domain/AppointmentRefuseMessage.java
@@ -1,0 +1,16 @@
+package com.swyp3.babpool.domain.appointment.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AppointmentRefuseMessage {
+    private Long requestProfileId;
+    private String refuseMessage;
+
+    @Builder
+    public AppointmentRefuseMessage(Long requestProfileId, String refuseMessage) {
+        this.requestProfileId = requestProfileId;
+        this.refuseMessage = refuseMessage;
+    }
+}

--- a/src/main/java/com/swyp3/babpool/domain/appointment/exception/eoorcode/AppointmentErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/exception/eoorcode/AppointmentErrorCode.java
@@ -15,7 +15,7 @@ public enum AppointmentErrorCode implements CustomErrorCode {
     APPOINTMENT_DONE_NOT_FOUND(HttpStatus.NOT_FOUND, "완료한 밥약이 존재하지 않습니다."),
     APPOINTMENT_REFUSE_NOT_FOUND(HttpStatus.NOT_FOUND, "거절된 밥약이 존재하지 않습니다."),
     APPOINTMENT_POSSIBLE_DATETIME_NOT_FOUND(HttpStatus.NOT_FOUND, "밥약 가능 시간이 존재하지 않습니다."),
-    ;
+    APPOINTMENT_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "대기 중인 밥약 요청이 아닙니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -106,6 +107,7 @@ public class ProfileServiceImpl implements ProfileService{
         return profileRepository.findByUserId(userId);
     }
 
+    @Transactional
     @Override
     public ProfileUpdateResponse updateProfileInfo(Long userId, ProfileUpdateRequest profileUpdateRequest) {
         Long profileId = profileRepository.findByUserId(userId).getProfileId();
@@ -117,7 +119,8 @@ public class ProfileServiceImpl implements ProfileService{
         return new ProfileUpdateResponse(profileId);
     }
 
-    private void updatePossibleDateTime(Long profileId, ProfileUpdateRequest profileUpdateRequest) {
+    @Transactional
+    public void updatePossibleDateTime(Long profileId, ProfileUpdateRequest profileUpdateRequest) {
         profileRepository.deletePossibleTimes(profileId);
         profileRepository.deletePossibleDates(profileId);
 

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -62,10 +62,14 @@ public class UserServiceImpl implements UserService{
         MyPageUserDaoDto myPageUserDaoDto= userRepository.findMyProfile(userId);
         Profile profile = profileService.getByUserId(userId);
         ReviewCountByTypeResponse reviewCountByType = reviewService.getReviewCountByType(profile.getProfileId());
+        List<AppointmentHistoryDoneResponse> appointmentHistories = getAppointmentHistories(userId);
+        MyPageResponse myPageResponse = new MyPageResponse(myPageUserDaoDto, reviewCountByType, appointmentHistories);
+        return myPageResponse;
+    }
 
+    private List<AppointmentHistoryDoneResponse> getAppointmentHistories(Long userId) {
         List<AppointmentHistoryDoneResponse> doneAppointmentList = appointmentRepository.findDoneAppointmentListByRequesterId(userId);
 
-        log.info("test: " +doneAppointmentList.size());
         // appointmentFixDateTime을 기준으로 내림차순으로 정렬
         Collections.sort(doneAppointmentList, Comparator.comparing(AppointmentHistoryDoneResponse::getAppointmentFixDateTime).reversed());
 
@@ -74,8 +78,7 @@ public class UserServiceImpl implements UserService{
             doneAppointmentList = doneAppointmentList.subList(0, 2);
         }
 
-        MyPageResponse myPageResponse = new MyPageResponse(myPageUserDaoDto, reviewCountByType, doneAppointmentList);
-        return myPageResponse;
+        return doneAppointmentList;
     }
 
     private boolean isAlreadyRegisteredUser(String userUuid) {

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -62,14 +62,10 @@ public class UserServiceImpl implements UserService{
         MyPageUserDaoDto myPageUserDaoDto= userRepository.findMyProfile(userId);
         Profile profile = profileService.getByUserId(userId);
         ReviewCountByTypeResponse reviewCountByType = reviewService.getReviewCountByType(profile.getProfileId());
-        List<AppointmentHistoryDoneResponse> appointmentHistories = getAppointmentHistories(userId);
-        MyPageResponse myPageResponse = new MyPageResponse(myPageUserDaoDto, reviewCountByType, appointmentHistories);
-        return myPageResponse;
-    }
 
-    private List<AppointmentHistoryDoneResponse> getAppointmentHistories(Long userId) {
         List<AppointmentHistoryDoneResponse> doneAppointmentList = appointmentRepository.findDoneAppointmentListByRequesterId(userId);
 
+        log.info("test: " +doneAppointmentList.size());
         // appointmentFixDateTime을 기준으로 내림차순으로 정렬
         Collections.sort(doneAppointmentList, Comparator.comparing(AppointmentHistoryDoneResponse::getAppointmentFixDateTime).reversed());
 
@@ -78,7 +74,8 @@ public class UserServiceImpl implements UserService{
             doneAppointmentList = doneAppointmentList.subList(0, 2);
         }
 
-        return doneAppointmentList;
+        MyPageResponse myPageResponse = new MyPageResponse(myPageUserDaoDto, reviewCountByType, doneAppointmentList);
+        return myPageResponse;
     }
 
     private boolean isAlreadyRegisteredUser(String userUuid) {

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -28,6 +28,7 @@ import com.swyp3.babpool.infra.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -85,7 +86,8 @@ public class UserServiceImpl implements UserService{
         return !findUser.getUserGrade().equals("none");
     }
 
-    private User insertUserExtraInfo(SignUpRequestDTO signUpRequest) {
+    @Transactional
+    public User insertUserExtraInfo(SignUpRequestDTO signUpRequest) {
         Long userId = uuidService.getUserIdByUuid(signUpRequest.getUserUuid());
         userRepository.updateSignUpInfo(userId, signUpRequest.getUserGrade());
 
@@ -137,7 +139,8 @@ public class UserServiceImpl implements UserService{
         return new LoginResponseWithRefreshToken(loginResponseDTO,refreshToken);
     }
 
-    private User createUser(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
+    @Transactional
+    public User createUser(AuthPlatform authPlatform, AuthMemberResponse authMemberResponse) {
         User user = User.builder()
                 .email(authMemberResponse.getEmail())
                 .nickName(authMemberResponse.getNickname())

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -209,4 +209,15 @@
         </foreach>
     </insert>
 
+    <update id="updateAppointmentReject" parameterType="com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest">
+        UPDATE t_appointment
+        SET appointment_status='REJECT',
+            appointment_modify_date=#{modifyDate}
+        WHERE appointment_id=#{appointmentId}
+    </update>
+
+    <insert id="saveRefuseData" parameterType="com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest">
+        INSERT INTO t_refuse(appointment_id,refuse_type,refuse_cause_content)
+        VALUES ( #{appointmentId}, #{refuseType}, #{refuseMessage} )
+    </insert>
 </mapper>

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -212,7 +212,7 @@
     <update id="updateAppointmentReject" parameterType="com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest">
         UPDATE t_appointment
         SET appointment_status='REJECT',
-            appointment_modify_date=#{modifyDate}
+            appointment_modify_date=CURRENT_TIMESTAMP()
         WHERE appointment_id=#{appointmentId}
     </update>
 


### PR DESCRIPTION
Resolves #72 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 밥약 거절 시 DB 업데이트 및 거절 알림 전송

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- @Transactional 적용
  - 이전에 UserServiceImpl, ProfileServiceImpl에도 적용안한 메소드가 있어서 적용했습니다.
 
@proHyundo 님께 질문드립니다!!
- modifyDate를 LocalDate.now()를 이용해 직접 업데이트를 해주었는데, myBatis에서 자동으로 하는 방법이 있는지 궁금합니다.
- 응답으로 줄 데이터가 없어서 okMessage를 내려주었는데 어떻게 생각하시는지 궁금합니다.
- 해당 api를 요청한 경우는 사용자가 직접 거절 버튼을 누른 경우인데, 요청이 만료되어 거절되는 경우는 별도의 api를 만들어야하는 건지 궁금합니다.

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->