### PR TITLE
refactor(profile, signout): Update profile list response field, Update signout response, Update profile image update logic

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
@@ -20,7 +20,7 @@ public class ProfileApi {
     public ApiResponse<ProfileUpdateResponse> updateProfileCard(@RequestAttribute(value = "userId") Long userId,
                                                                 @RequestPart(value = "profileImageFile") MultipartFile multipartFile,
                                                                 @RequestPart(value = "profileInfo") ProfileUpdateRequest profileUpdateRequest) {
-        profileService.uploadProfileImage(userId, multipartFile);
+        profileService.updateProfileImage(userId, multipartFile);
         ProfileUpdateResponse response =  profileService.updateProfileInfo(userId, profileUpdateRequest);
         return ApiResponse.ok(response);
     }

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileService.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileService.java
@@ -16,7 +16,7 @@ public interface ProfileService {
     void saveProfile(Profile profile);
     Profile getByUserId(Long userId);
     //사용자 지정 이미지로 수정
-    String uploadProfileImage(Long userId, MultipartFile multipartFile);
+    String updateProfileImage(Long userId, MultipartFile multipartFile);
     //사용자가 프로필 카드 업데이트
     ProfileUpdateResponse updateProfileInfo(Long userId, ProfileUpdateRequest profileUpdateRequest);
 

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -87,13 +88,41 @@ public class ProfileServiceImpl implements ProfileService{
     }
 
     @Override
-    public String uploadProfileImage(Long userId, MultipartFile multipartFile) {
+    public String updateProfileImage(Long userId, MultipartFile multipartFile) {
+        if(verifyNoImageFile(multipartFile)){
+            return null;
+        }
+
+        deleteExistImageIfUserSelfUploaded(userId);
         String uploadedImageUrl = awsS3Provider.uploadImage(multipartFile);
+
         profileRepository.updateProfileImageUrl(Profile.builder()
                 .userId(userId)
                 .profileImageUrl(uploadedImageUrl)
                 .build());
         return uploadedImageUrl;
+    }
+
+    private void deleteExistImageIfUserSelfUploaded(Long userId) {
+        Profile targetProfile = profileRepository.findByUserId(userId);
+        // 만약 프로필 이미지가 없다면 삭제할 필요가 없다.
+        if(StringUtils.hasText(targetProfile.getProfileImageUrl())){
+            return;
+        }
+        // 만약 프로필 이미지 URL 이 S3에 저장된 이미지 URL이 아니라면(카카오,구글 CDN) 삭제할 필요가 없다.
+        if(!targetProfile.getProfileImageUrl().startsWith(awsS3Provider.getAmazonS3ClientUrlPrefix())){
+            log.info("ProfileService.deleteExistImageIfUserSelfUploaded, S3에 저장된 이미지가 아닙니다. URL: {}",targetProfile.getProfileImageUrl());
+            return;
+        }
+        awsS3Provider.deleteImage(targetProfile.getProfileImageUrl());
+    }
+
+    private boolean verifyNoImageFile(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()){
+            log.info("ProfileService.checkNoImageFile, 첨부된 이미지 파일이 없습니다.");
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfilePagingResponse.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/response/ProfilePagingResponse.java
@@ -14,7 +14,6 @@ import java.util.List;
 public class ProfilePagingResponse {
 
     private Long profileId;
-    private Long userId;
     private String profileImageUrl;
     private String profileIntro;
     private String profileContents;
@@ -24,9 +23,8 @@ public class ProfilePagingResponse {
     private String userNickname;
 
     @Builder
-    public ProfilePagingResponse(Long profileId, Long userId, String profileImageUrl, String profileIntro, String profileContents, LocalDateTime profileModifyDate, List<String> keywordNameList, String userGrade, String userNickname) {
+    public ProfilePagingResponse(Long profileId, String profileImageUrl, String profileIntro, String profileContents, LocalDateTime profileModifyDate, List<String> keywordNameList, String userGrade, String userNickname) {
         this.profileId = profileId;
-        this.userId = userId;
         this.profileImageUrl = profileImageUrl;
         this.profileIntro = profileIntro;
         this.profileContents = profileContents;
@@ -39,7 +37,6 @@ public class ProfilePagingResponse {
     public static ProfilePagingResponse of(ProfilePagingDto profilePagingDto) {
         return ProfilePagingResponse.builder()
                 .profileId(profilePagingDto.getProfileId())
-                .userId(profilePagingDto.getUserId())
                 .profileImageUrl(profilePagingDto.getProfileImageUrl())
                 .profileIntro(profilePagingDto.getProfileIntro())
                 .profileContents(profilePagingDto.getProfileContents())

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
@@ -1,9 +1,11 @@
 package com.swyp3.babpool.domain.user.api;
 
+import com.swyp3.babpool.global.common.response.ApiResponseWithCookie;
 import com.swyp3.babpool.global.jwt.application.JwtServiceImpl;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +19,7 @@ public class UserSignOutApi {
     private final JwtServiceImpl jwtService;
 
     @PostMapping("/api/user/sign/out")
-    public void signOut(HttpServletRequest request){
+    public ApiResponseWithCookie signOut(HttpServletRequest request){
         Cookie[] cookies = request.getCookies();
         if(cookies != null){
             Optional<Cookie> optionalCookie = Arrays.stream(cookies)
@@ -25,6 +27,14 @@ public class UserSignOutApi {
                     .findAny();
             optionalCookie.ifPresent(cookie -> jwtService.logout(cookie.getValue()));
         }
+        return ApiResponseWithCookie.ofCookie(
+                HttpStatus.OK,
+                "sign out success",
+                null,
+                "refreshToken",
+                "",
+                true,
+                0);
     }
 
 }

--- a/src/main/java/com/swyp3/babpool/global/jwt/application/JwtServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/global/jwt/application/JwtServiceImpl.java
@@ -8,11 +8,14 @@ import com.swyp3.babpool.infra.redis.dao.TokenRedisRepository;
 import com.swyp3.babpool.infra.redis.domain.TokenForRedis;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtServiceImpl implements JwtService{
@@ -57,9 +60,11 @@ public class JwtServiceImpl implements JwtService{
 
     @Override
     public void logout(String refreshTokenFromCookie) {
-        tokenRepository.findById(refreshTokenFromCookie)
-                .orElseThrow(() -> new BabpoolJwtException(JwtExceptionErrorCode.REFRESH_TOKEN_NOT_FOUND,
-                "refresh token not found in redis, while logout"));
-        tokenRepository.deleteById(refreshTokenFromCookie);
+        Optional<TokenForRedis> tokenForRedisOptional = tokenRepository.findById(refreshTokenFromCookie);
+        if (tokenForRedisOptional.isPresent()) {
+            tokenRepository.deleteById(refreshTokenFromCookie);
+        }else{
+            log.error("refresh token not found in redis, while logout. token : {}", refreshTokenFromCookie);
+        }
     }
 }

--- a/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
+++ b/src/main/java/com/swyp3/babpool/infra/s3/application/AwsS3Provider.java
@@ -92,4 +92,8 @@ public class AwsS3Provider {
         return true;
     }
 
+    public String getAmazonS3ClientUrlPrefix() {
+        // "https://babpool-image-bucket.s3.ap-northeast-2.amazonaws.com/static/"
+        return amazonS3Client.getUrl(bucket, S3_BUCKET_DIRECTORY_NAME).toString();
+    }
 }


### PR DESCRIPTION
Resolves #74 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- profile과 signout 범위에서 코드를 개선했습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 프로필 페이징 리스트 응답 시, userId가 응답에 포함된 오류를 해결했습니다.
- 사용자 로그아웃 시, refreshToken 쿠키를 클라이언트 측에서 제거되기 위해 maxAge 0 의 쿠키를 응답하도록 변경했습니다.
- 프로필 이미지 수정 시, 기존에 존재하는 프로필 이미지 URL 이 밥풀 서비스의 S3 버켓에 저장된 이미지라면 삭제 처리 후 새 이미지 파일이 업로드 되도록 구현 로직을 수정했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- maxAge 0 쿠키를 응답하면, 올바르게 사용자 측에서 쿠키가 삭제되는 것이 맞는지 확인 받고 싶습니다.

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->