### PR TITLE
feat(scheduler): Add scheduler for appointment status to expire automatically

### DIFF
--- a/src/main/java/com/swyp3/babpool/BabpoolApplication.java
+++ b/src/main/java/com/swyp3/babpool/BabpoolApplication.java
@@ -2,7 +2,9 @@ package com.swyp3.babpool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BabpoolApplication {
 

--- a/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
@@ -43,4 +43,6 @@ public interface AppointmentRepository {
     void updateAppointmentReject(AppointmentRefuseRequest appointmentRefuseRequest);
 
     void saveRefuseData(AppointmentRefuseRequest appointmentRefuseRequest);
+
+    int updateExpiredStatus();
 }

--- a/src/main/java/com/swyp3/babpool/global/config/AppointmentSchedulerConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/AppointmentSchedulerConfig.java
@@ -1,0 +1,25 @@
+package com.swyp3.babpool.global.config;
+
+import com.swyp3.babpool.domain.appointment.dao.AppointmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AppointmentSchedulerConfig {
+
+    private final AppointmentRepository appointmentRepository;
+
+    // 1시간 마다 업데이트, 초기 1분 딜레이
+    @Scheduled(fixedRate = 1000 * 60 * 60, initialDelay = 1000 * 60)
+    public void scheduleAppointmentUpdateExpiredStatus() {
+        log.info("scheduleAppointmentUpdateExpiredStatus start alert. Current LocalDateTime {}", LocalDateTime.now());
+        int updatedRows = appointmentRepository.updateExpiredStatus();
+        log.info("scheduleAppointmentUpdateExpiredStatus end alert. Updated Rows {}", updatedRows);
+    }
+}

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -216,6 +216,17 @@
         WHERE appointment_id=#{appointmentId}
     </update>
 
+    <update id="updateExpiredStatus">
+        <![CDATA[
+        UPDATE t_appointment
+            SET appointment_status='EXPIRE',
+                appointment_modify_date=CURRENT_TIMESTAMP()
+        WHERE
+            appointment_status='WAITING'
+        AND DATE_ADD(appointment_create_date, INTERVAL 1 DAY) < CURRENT_TIMESTAMP();
+        ]]>
+    </update>
+
     <insert id="saveRefuseData" parameterType="com.swyp3.babpool.domain.appointment.api.request.AppointmentRefuseRequest">
         INSERT INTO t_refuse(appointment_id,refuse_type,refuse_cause_content)
         VALUES ( #{appointmentId}, #{refuseType}, #{refuseMessage} )


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 밥약 요청을 받은 경우 24시간 이내에 수락/거절하지 않으면 appointment_status를 EXPIRE 으로 업데이트 되어야 합니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 스프링 부트 스케줄러를 사용해 해당 이슈를 해결했습니다.
- 스케줄러를 사용하기 위해 `BabpoolApplication` 클래스에 `@EnableScheduling` 어노테이션이 추가되었습니다.
- 1시간 마다 업데이트를 위한 쿼리를 수행하며, 애플리케이션이 부팅되는 시간을 고려해 초기 1분 딜레이를 설정했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- [참고한 링크 : [Spring Boot] @Scheduled를 이용한 스케쥴러 구현하기](https://velog.io/@developer_khj/Spring-Boot-Scheduler-Scheduled)

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->