### PR TITLE
refactor(appointment): Update findAppointmentPossibleDateTimeByProfil… query

### DIFF
--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -154,7 +154,7 @@
         FROM t_possible_date pdate
             INNER JOIN t_possible_time ptime ON pdate.possible_date_id = ptime.possible_date_id
             LEFT JOIN t_appointment appoint ON ptime.possible_time_id = appoint.possible_time_id
-                        AND appoint.appointment_status = 'ACCEPT'
+                        AND appoint.appointment_status IN ('ACCEPT', 'DONE')
         WHERE
             pdate.profile_id = #{profileId}
         AND pdate.possible_date >= DATE_FORMAT(NOW() ,'%Y-%m-01')

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -152,11 +152,14 @@
             pdate.possible_date AS possibleDate,
             ptime.possible_time_start AS possibleTime
         FROM t_possible_date pdate
-                 INNER JOIN t_possible_time ptime ON pdate.possible_date_id = ptime.possible_date_id
+            INNER JOIN t_possible_time ptime ON pdate.possible_date_id = ptime.possible_date_id
+            LEFT JOIN t_appointment appoint ON ptime.possible_time_id = appoint.possible_time_id
+                        AND appoint.appointment_status = 'ACCEPT'
         WHERE
             pdate.profile_id = #{profileId}
-          AND pdate.possible_date >= DATE_FORMAT(NOW() ,'%Y-%m-01')
-        ORDER BY pdate.possible_date ASC, ptime.possible_time_start ASC
+        AND pdate.possible_date >= DATE_FORMAT(NOW() ,'%Y-%m-01')
+        AND appoint.appointment_id IS NULL
+        ORDER BY pdate.possible_date ASC, ptime.possible_time_start ASC;
     </select>
 
     <!-- ######################################## INSERT ######################################## -->


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 약속 수락 시, 사용자가 활성화 해둔 일정/시간을 삭제하려 했으나 외래키에 의해 삭제 불가했습니다.
- on delete cascade 또는 set null 설정을 주는 것은 `t_appointment` 테이블에 `appointment_time_id` 속성의 존재 의미가 사라집니다.
- 따라서 가장 적은 변경으로 해당 문제를 해결하기 위해서, 특정 사용자에게 요청 가능한 일정/시간을 조회하는 SELECT 쿼리를 개선할 필요가 있었습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- AND appoint.appointment_id IS NULL 조건의 필요성 이 조건은 LEFT JOIN을 사용하여 t_appointment 테이블과 조인했을 때 사용됩니다. LEFT JOIN을 통해, t_possible_time 테이블의 possible_time_id와 일치하면서 appointment_status가 "ACCEPT"인 t_appointment 테이블의 행을 조인합니다. 그러나, 우리의 목적은 "ACCEPT" 상태인 약속을 제외하는 것이기 때문에, 조인된 결과에서 실제로 "ACCEPT" 상태인 행이 존재하는 경우 해당 possible_time_id를 결과에서 제외해야 합니다. appoint.appointment_id IS NULL 조건은 t_appointment 테이블과의 조인으로 인해 추가된 행들 중에서 appointment_id 필드가 NULL인 행, 즉 t_possible_time 테이블의 possible_time_id에 대응하는 "ACCEPT" 상태의 약속이 t_appointment 테이블에 존재하지 않는 경우만 결과에 포함시키기 위해 사용됩니다. 따라서, 이 조건은 "ACCEPT"된 약속을 제외하고 가능한 시간을 조회하는 데 필수적입니다. (출처: GPT-4)


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->