### PR TITLE
feat: Add sign out and sign down

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/api/ProfileApi.java
@@ -19,7 +19,7 @@ public class ProfileApi {
 
     @PostMapping("/update")
     public ApiResponse<ProfileUpdateResponse> updateProfileCard(@RequestAttribute(value = "userId") Long userId,
-                                                                @RequestPart(value = "profileImageFile") MultipartFile multipartFile,
+                                                                @RequestPart(value = "profileImageFile", required = false) MultipartFile multipartFile,
                                                                 @RequestPart(value = "profileInfo") ProfileUpdateRequest profileUpdateRequest) {
         profileService.updateProfileImage(userId, multipartFile);
         ProfileUpdateResponse response =  profileService.updateProfileInfo(userId, profileUpdateRequest);

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
@@ -55,4 +55,10 @@ public class UserApi {
         UserGradeResponse userGradeResponse = userService.getUserGrade(userId);
         return ApiResponse.ok(userGradeResponse);
     }
+
+    @PostMapping("/sign/down")
+    public ApiResponse signDown(@RequestAttribute(value = "userId") Long userId, @RequestBody String exitReason){
+        userService.signDown(userId, exitReason);
+        return ApiResponse.ok("회원탈퇴에 성공하였습니다");
+    }
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -80,8 +82,12 @@ public class UserApi {
     }
 
     @PostMapping("/sign/down")
-    public ApiResponse signDown(@RequestAttribute(value = "userId") Long userId, @RequestBody String exitReason){
-        userService.signDown(userId, exitReason);
-        return ApiResponse.ok("회원탈퇴에 성공하였습니다");
+    public ResponseEntity<ApiResponse> signDown(@RequestAttribute(value = "userId") Long userId,
+                                                @CookieValue(value = "refreshToken", required = false) String refreshTokenFromCookie,
+                                                @RequestBody Map<String, Object> data){
+        userService.signDown(userId, data.get("exitReason").toString(), refreshTokenFromCookie);
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken("", 0).toString())
+                .body(ApiResponse.ok("sign down success"));
     }
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
@@ -4,15 +4,17 @@ import com.swyp3.babpool.domain.user.application.response.MyPageResponse;
 import com.swyp3.babpool.domain.user.application.UserService;
 import com.swyp3.babpool.domain.user.application.response.UserGradeResponse;
 import com.swyp3.babpool.global.common.response.ApiResponse;
-import com.swyp3.babpool.global.common.response.ApiResponseWithCookie;
 import com.swyp3.babpool.domain.user.api.requset.LoginRequestDTO;
 import com.swyp3.babpool.domain.user.api.requset.SignUpRequestDTO;
 import com.swyp3.babpool.domain.user.application.response.LoginResponseDTO;
 import com.swyp3.babpool.domain.user.application.response.LoginResponseWithRefreshToken;
+import com.swyp3.babpool.global.common.response.CookieProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -23,27 +25,48 @@ public class UserApi {
     private final UserService userService;
 
     @PostMapping("/sign/in")
-    public ApiResponseWithCookie<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO loginRequest){
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO loginRequest){
+//    public ApiResponseWithCookie<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO loginRequest){ // 변경 전
         LoginResponseWithRefreshToken loginResponseData = userService.login(loginRequest);
         Boolean isRegistered = loginResponseData.getLoginResponseDTO().getIsRegistered();
 
+        //로그인 성공한 경우 - 변경 전
+//        if(isRegistered)
+//            return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK,"로그인에 성공하였습니다",
+//                    loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
+//        //추가정보 입력이 필요한 경우
+//        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.UNAUTHORIZED,"추가정보 입력이 필요한 사용자입니다",
+//                loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
+
         //로그인 성공한 경우
-        if(isRegistered)
-            return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK,"로그인에 성공하였습니다",
-                    loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
-        //추가정보 입력이 필요한 경우
-        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.UNAUTHORIZED,"추가정보 입력이 필요한 사용자입니다",
-                loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
+        if(isRegistered) {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken(loginResponseData.getRefreshToken()).toString())
+                    .body(ApiResponse.ok(loginResponseData.getLoginResponseDTO()));
+        }
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.of(HttpStatus.UNAUTHORIZED, loginResponseData.getLoginResponseDTO()));
     }
+
+//    @PostMapping("/sign/up")
+//    public ApiResponseWithCookie<LoginResponseDTO> signUp(@RequestBody @Valid SignUpRequestDTO signUpRequest){
+//        LoginResponseWithRefreshToken loginResponseData = userService.signUp(signUpRequest);
+//
+//        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK,"회원가입에 성공하였습니다",
+//                loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
+//    }
 
     @PostMapping("/sign/up")
-    public ApiResponseWithCookie<LoginResponseDTO> signUp(@RequestBody @Valid SignUpRequestDTO signUpRequest){
-        LoginResponseWithRefreshToken loginResponseData = userService.signUp(signUpRequest);
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> signUp(@RequestBody @Valid SignUpRequestDTO signUpRequest){
+    LoginResponseWithRefreshToken loginResponseData = userService.signUp(signUpRequest);
 
-        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK,"회원가입에 성공하였습니다",
-                loginResponseData.getLoginResponseDTO(), loginResponseData.getRefreshToken());
-    }
-
+    return ResponseEntity
+            .status(HttpStatus.OK)
+            .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken(loginResponseData.getRefreshToken()).toString())
+            .body(ApiResponse.ok(loginResponseData.getLoginResponseDTO()));
+}
     @GetMapping("/mypage")
     public ApiResponse<MyPageResponse> getMyPage(@RequestAttribute(value = "userId") Long userId){
         MyPageResponse myPageResponse = userService.getMyPage(userId);

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
@@ -1,20 +1,19 @@
 package com.swyp3.babpool.domain.user.api;
 
-import com.swyp3.babpool.global.common.response.ApiResponseWithCookie;
+import com.swyp3.babpool.global.common.response.ApiResponse;
+import com.swyp3.babpool.global.common.response.CookieProvider;
 import com.swyp3.babpool.global.jwt.JwtAuthenticator;
 import com.swyp3.babpool.global.jwt.application.JwtServiceImpl;
 import com.swyp3.babpool.infra.auth.service.AuthService;
-import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Arrays;
-import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -26,28 +25,18 @@ public class UserSignOutApi {
     private final JwtAuthenticator jwtAuthenticator;
 
     @PostMapping("/api/user/sign/out")
-    public ApiResponseWithCookie signOut(HttpServletRequest request){
-        log.info("sign out request start");
-        Cookie[] cookies = request.getCookies();
-        if(cookies != null){
-            Optional<Cookie> optionalCookie = Arrays.stream(cookies)
-                    .filter(cookie -> cookie.getName().equals("refreshToken"))
-                    .findAny();
-            optionalCookie.ifPresent(cookie -> {
-                String refreshTokenFromCookie = cookie.getValue();
-                Long userId = jwtAuthenticator.jwtRefreshTokenToUserIdResolver(refreshTokenFromCookie);
-                authService.socialServiceSignOut(userId, authService.getAuthPlatformByUserId(userId));
-                jwtService.logout(refreshTokenFromCookie);
-            });
+    public ResponseEntity<ApiResponse<String>> signOut(@CookieValue(value = "refreshToken", required = false) String refreshTokenFromCookie){
+        log.info("/api/user/sign/out sign out request start");
+        if(StringUtils.hasText(refreshTokenFromCookie)){
+            log.info("/api/user/sign/out refreshTokenFromCookie : " + refreshTokenFromCookie);
+            Long userId = jwtAuthenticator.jwtRefreshTokenToUserIdResolver(refreshTokenFromCookie);
+            authService.socialServiceSignOut(userId, authService.getAuthPlatformByUserId(userId));
+            jwtService.logout(refreshTokenFromCookie);
         }
-        return ApiResponseWithCookie.ofCookie(
-                HttpStatus.OK,
-                "sign out success",
-                null,
-                "refreshToken",
-                "",
-                true,
-                0);
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken("", 0).toString())
+                .body(ApiResponse.ok("sign out success"));
+
     }
 
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserSignOutApi.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Arrays;
 import java.util.Optional;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserSignOutApi {
@@ -25,6 +27,7 @@ public class UserSignOutApi {
 
     @PostMapping("/api/user/sign/out")
     public ApiResponseWithCookie signOut(HttpServletRequest request){
+        log.info("sign out request start");
         Cookie[] cookies = request.getCookies();
         if(cookies != null){
             Optional<Cookie> optionalCookie = Arrays.stream(cookies)

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
@@ -9,6 +9,9 @@ import com.swyp3.babpool.domain.user.application.response.UserGradeResponse;
 public interface UserService {
     LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest);
     LoginResponseWithRefreshToken signUp(SignUpRequestDTO signUpRequest);
+
+    void signDown(Long userId, String exitReason);
+
     MyPageResponse getMyPage(Long userId);
 
     UserGradeResponse getUserGrade(Long userId);

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
@@ -10,7 +10,7 @@ public interface UserService {
     LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest);
     LoginResponseWithRefreshToken signUp(SignUpRequestDTO signUpRequest);
 
-    void signDown(Long userId, String exitReason);
+    void signDown(Long userId, String exitReason, String refreshTokenFromCookie);
 
     MyPageResponse getMyPage(Long userId);
 

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -59,10 +59,11 @@ public class UserServiceImpl implements UserService{
         return getLoginResponse(user);
     }
 
+    @Transactional
     @Override
     public void signDown(Long userId, String exitReason) {
-        AuthPlatform authPlatform = authService.getAuthPlatformByUserId(userId);
-        authService.socialServiceDisconnect(userId, authPlatform);
+        AuthPlatform authPlatformName = authService.getAuthPlatformByUserId(userId);
+        authService.socialServiceDisconnect(userId, authPlatformName);
 
         int updatedRows = userRepository.updateUserStateByUserId(userId, UserStatus.EXIT);
         if(updatedRows!=1){

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -61,7 +61,7 @@ public class UserServiceImpl implements UserService{
 
     @Transactional
     @Override
-    public void signDown(Long userId, String exitReason) {
+    public void signDown(Long userId, String exitReason, String refreshTokenFromCookie) {
         AuthPlatform authPlatformName = authService.getAuthPlatformByUserId(userId);
         authService.socialServiceDisconnect(userId, authPlatformName);
 
@@ -70,6 +70,7 @@ public class UserServiceImpl implements UserService{
             throw new SignDownException(SignDownExceptionErrorCode.FAILED_TO_UPDATE_USER_STATE, "회원탈퇴에 실패하였습니다");
         }
         exitInfoRepository.saveExitInfo(userId, exitReason);
+        jwtService.logout(refreshTokenFromCookie);
     }
 
     @Override

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -1,6 +1,5 @@
 package com.swyp3.babpool.domain.user.application;
 
-import com.swyp3.babpool.domain.appointment.application.AppointmentService;
 import com.swyp3.babpool.domain.appointment.application.response.AppointmentHistoryDoneResponse;
 import com.swyp3.babpool.domain.appointment.dao.AppointmentRepository;
 import com.swyp3.babpool.domain.profile.application.ProfileService;
@@ -8,10 +7,14 @@ import com.swyp3.babpool.domain.profile.domain.Profile;
 import com.swyp3.babpool.domain.review.application.ReviewService;
 import com.swyp3.babpool.domain.review.application.response.ReviewCountByTypeResponse;
 import com.swyp3.babpool.domain.user.application.response.*;
+import com.swyp3.babpool.domain.user.dao.ExitInfoRepository;
 import com.swyp3.babpool.domain.user.dao.UserRepository;
 import com.swyp3.babpool.domain.user.domain.User;
 import com.swyp3.babpool.domain.user.domain.UserRole;
+import com.swyp3.babpool.domain.user.domain.UserStatus;
+import com.swyp3.babpool.domain.user.exception.SignDownException;
 import com.swyp3.babpool.domain.user.exception.SignUpException;
+import com.swyp3.babpool.domain.user.exception.errorcode.SignDownExceptionErrorCode;
 import com.swyp3.babpool.domain.user.exception.errorcode.SignUpExceptionErrorCode;
 import com.swyp3.babpool.global.jwt.application.JwtService;
 import com.swyp3.babpool.global.jwt.application.response.JwtPairDto;
@@ -28,7 +31,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -42,6 +44,7 @@ public class UserServiceImpl implements UserService{
     private final ProfileService profileService;
     private final ReviewService reviewService;
     private final AppointmentRepository appointmentRepository;
+    private final ExitInfoRepository exitInfoRepository;
 
     public LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest) {
         AuthMemberResponse kakaoPlatformMember = authService.getUserDataByCode(loginRequest.getCode());
@@ -54,6 +57,18 @@ public class UserServiceImpl implements UserService{
                     "이미 데이터베이스에 등록된 사용자이므로 새로운 회원가입을 진행할 수 없습니다.");
         User user = insertUserExtraInfo(signUpRequest);
         return getLoginResponse(user);
+    }
+
+    @Override
+    public void signDown(Long userId, String exitReason) {
+        AuthPlatform authPlatform = authService.getAuthPlatformByUserId(userId);
+        authService.socialServiceDisconnect(userId, authPlatform);
+
+        int updatedRows = userRepository.updateUserStateByUserId(userId, UserStatus.EXIT);
+        if(updatedRows!=1){
+            throw new SignDownException(SignDownExceptionErrorCode.FAILED_TO_UPDATE_USER_STATE, "회원탈퇴에 실패하였습니다");
+        }
+        exitInfoRepository.saveExitInfo(userId, exitReason);
     }
 
     @Override

--- a/src/main/java/com/swyp3/babpool/domain/user/dao/ExitInfoRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/dao/ExitInfoRepository.java
@@ -1,8 +1,9 @@
 package com.swyp3.babpool.domain.user.dao;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ExitInfoRepository {
-    void saveExitInfo(Long userId, String exitReason);
+    void saveExitInfo(@Param("userId") Long userId, @Param("exitReason") String exitReason);
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/dao/ExitInfoRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/dao/ExitInfoRepository.java
@@ -1,0 +1,8 @@
+package com.swyp3.babpool.domain.user.dao;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ExitInfoRepository {
+    void saveExitInfo(Long userId, String exitReason);
+}

--- a/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
@@ -25,5 +25,5 @@ public interface UserRepository {
 
     String findUserGradeById(Long userId);
 
-    int updateUserStateByUserId(Long userId, UserStatus userStatus);
+    int updateUserStateByUserId(@Param("userId") Long userId, @Param("userStatus") UserStatus userStatus);
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/dao/UserRepository.java
@@ -2,6 +2,7 @@ package com.swyp3.babpool.domain.user.dao;
 
 import com.swyp3.babpool.domain.user.application.response.MyPageUserDaoDto;
 import com.swyp3.babpool.domain.user.domain.User;
+import com.swyp3.babpool.domain.user.domain.UserStatus;
 import com.swyp3.babpool.infra.auth.AuthPlatform;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -21,5 +22,8 @@ public interface UserRepository {
     void saveKeyword(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
 
     MyPageUserDaoDto findMyProfile(Long userId);
+
     String findUserGradeById(Long userId);
+
+    int updateUserStateByUserId(Long userId, UserStatus userStatus);
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/domain/UserStatus.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/domain/UserStatus.java
@@ -1,5 +1,8 @@
 package com.swyp3.babpool.domain.user.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum UserStatus {
     EXIT,
     ACTIVE,

--- a/src/main/java/com/swyp3/babpool/domain/user/exception/SignDownException.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/exception/SignDownException.java
@@ -1,0 +1,13 @@
+package com.swyp3.babpool.domain.user.exception;
+
+import com.swyp3.babpool.domain.user.exception.errorcode.SignDownExceptionErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SignDownException extends RuntimeException{
+
+    private final SignDownExceptionErrorCode signDownExceptionErrorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/domain/user/exception/errorcode/SignDownExceptionErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/exception/errorcode/SignDownExceptionErrorCode.java
@@ -1,0 +1,15 @@
+package com.swyp3.babpool.domain.user.exception.errorcode;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SignDownExceptionErrorCode implements CustomErrorCode {
+    FAILED_TO_UPDATE_USER_STATE(HttpStatus.INTERNAL_SERVER_ERROR,"회원탈퇴에 실패하였습니다.")
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/common/response/CookieProvider.java
+++ b/src/main/java/com/swyp3/babpool/global/common/response/CookieProvider.java
@@ -1,0 +1,34 @@
+package com.swyp3.babpool.global.common.response;
+
+import com.swyp3.babpool.global.common.response.config.ApiResponseConfigProperties;
+import lombok.Getter;
+import org.springframework.http.ResponseCookie;
+
+@Getter
+public class CookieProvider {
+
+    private static String domain = ApiResponseConfigProperties.getDomain();
+    private static Integer refreshTokenExpireDays = Integer.valueOf(ApiResponseConfigProperties.getRefreshTokenExpireDays());
+
+    public static ResponseCookie ofRefreshToken(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .domain(domain)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * refreshTokenExpireDays)
+                .build();
+    }
+
+    public static ResponseCookie ofRefreshToken(String refreshToken, Integer expireDays) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .domain(domain)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * expireDays)
+                .build();
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/jwt/JwtAuthenticator.java
+++ b/src/main/java/com/swyp3/babpool/global/jwt/JwtAuthenticator.java
@@ -28,4 +28,12 @@ public class JwtAuthenticator {
                             "Not found user id with uuid, while JwtAuthenticator request to UserUuidRepository"))
                 .getUserId();
     }
+
+    public Long jwtRefreshTokenToUserIdResolver(String refreshToken) {
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);
+        return jwtTokenUserIdResolver(claims.getSubject());
+    }
+
+
+
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/dao/AuthRepository.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/dao/AuthRepository.java
@@ -5,7 +5,11 @@ import com.swyp3.babpool.infra.auth.domain.Auth;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.Optional;
+
 @Mapper
 public interface AuthRepository {
     void save(Auth oauth);
+
+    Optional<Auth> findByUserId(Long userId);
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/exception/errorcode/AuthExceptionErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/exception/errorcode/AuthExceptionErrorCode.java
@@ -16,6 +16,8 @@ public enum AuthExceptionErrorCode implements CustomErrorCode {
     AUTH_ERROR_CONNECT_WITH_KAKAO(HttpStatus.INTERNAL_SERVER_ERROR, "Kakao로부터 id Token을 응답받는 과정 중 오류가 발생했습니다."),
     AUTH_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 소셜로그인 정보가 존재하지 않습니다."),
     NOT_SUPPORTED_AUTH_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜로그인 플랫폼입니다."),
+    AUTH_DISCONNECT_KAKAO_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Kakao와 연결 해제 중 오류가 발생했습니다."),
+    AUTH_SIGN_OUT_KAKAO_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Kakao 회원 로그아웃 중 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/swyp3/babpool/infra/auth/exception/errorcode/AuthExceptionErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/exception/errorcode/AuthExceptionErrorCode.java
@@ -8,12 +8,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthExceptionErrorCode implements CustomErrorCode {
-    AUTH_JWT_ERROR(HttpStatus.UNAUTHORIZED,"AUTH JWT에서 오류가 발생했습니다."),
-    AUTH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST,"유효하지 않은 토큰입니다."),
-    AUTH_MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED,"올바르지 않은 토큰입니다."),
-    AUTH_UNSUPPORTED_ID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED,"OAuth Identity Token의 형식이 올바르지 않습니다."),
-    AUTH_PUBLIC_KEY_ERROR(HttpStatus.UNAUTHORIZED,"OAuth Public Key 생성 중 오류가 발생했습니다."),
-    AUTH_ERROR_CONNECT_WITH_KAKAO(HttpStatus.INTERNAL_SERVER_ERROR,"Kakao로부터 id Token을 응답받는 과정 중 오류가 발생했습니다.");
+    AUTH_JWT_ERROR(HttpStatus.UNAUTHORIZED, "AUTH JWT에서 오류가 발생했습니다."),
+    AUTH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    AUTH_MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 토큰입니다."),
+    AUTH_UNSUPPORTED_ID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "OAuth Identity Token의 형식이 올바르지 않습니다."),
+    AUTH_PUBLIC_KEY_ERROR(HttpStatus.UNAUTHORIZED, "OAuth Public Key 생성 중 오류가 발생했습니다."),
+    AUTH_ERROR_CONNECT_WITH_KAKAO(HttpStatus.INTERNAL_SERVER_ERROR, "Kakao로부터 id Token을 응답받는 과정 중 오류가 발생했습니다."),
+    AUTH_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자의 소셜로그인 정보가 존재하지 않습니다."),
+    NOT_SUPPORTED_AUTH_PLATFORM(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜로그인 플랫폼입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 
 import java.security.PublicKey;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -57,6 +58,7 @@ public class KakaoProvider {
     }
 
     public void kakaoMemberSignOut(Long oauthId) {
+        log.info("KakaoProvider클래스 kakaoMemberSignOut메서드 oauthId: " + oauthId);
         WebClient webClient = WebClient.builder()
                 .baseUrl("https://kauth.kakao.com")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -66,7 +68,7 @@ public class KakaoProvider {
         params.add("target_id_type","user_id");
         params.add("target_id",oauthId.toString());
 
-        String responseJson = webClient.post()
+        Optional<String> responseJson = webClient.post()
                 .uri(uriBuilder -> uriBuilder.path("/v1/user/logout").build())
                 .header("Authorization", "KakaoAK " + KAKAO_SERVICE_APP_ADMIN_KEY)
                 .body(BodyInserters.fromFormData(params))
@@ -75,8 +77,13 @@ public class KakaoProvider {
                         clientResponse -> clientResponse.bodyToMono(String.class)
                                 .map(body -> new AuthException(AuthExceptionErrorCode.AUTH_SIGN_OUT_KAKAO_FAIL, body)))
                 .bodyToMono(String.class)
-                .doOnNext(response -> log.info("kakaoMemberSignOut response: " + response))
-                .block();
+                .doOnNext(response -> log.info("kakaoMemberSignOut response 응답 : " + response))
+                .blockOptional();
+
+        responseJson.ifPresentOrElse(
+                json -> log.info("kakaoMemberSignOut responseJson: " + json),
+                () -> log.info("kakaoMemberSignOut responseJson is empty")
+        );
 
         log.info("kakaoMemberSignOut responseJson: " + responseJson);
 

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
@@ -7,12 +7,19 @@ import com.swyp3.babpool.infra.auth.exception.errorcode.AuthExceptionErrorCode;
 import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.security.PublicKey;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoProvider {
@@ -23,6 +30,8 @@ public class KakaoProvider {
     private String iss;
     @Value("${property.oauth.kakao.client-id}")
     private String clientId;
+    @Value("${property.oauth.kakao.admin-key}")
+    private String KAKAO_SERVICE_APP_ADMIN_KEY;
 
     public AuthMemberResponse getKakaoPlatformMember(String identityToken){
         Map<String, String> headers = authJwtParser.parseHeaders(identityToken);
@@ -40,6 +49,38 @@ public class KakaoProvider {
             throw new AuthException(AuthExceptionErrorCode.AUTH_JWT_ERROR,
                     "OAuth Claim 값이 올바르지 않습니다.");
         }
+    }
+
+    public void kakaoMemberSignOut(Long userId) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        JSONObject response = webClient.post()
+                .uri(uriBuilder -> uriBuilder.path("/v1/user/logout").build())
+                .header("Authorization", "KakaoAK " + clientId)
+                .retrieve().bodyToMono(JSONObject.class).block();
+
+        log.info("kakaoMemberSignOut response: " + response.toString());
+    }
+
+    public void kakaoMemberDisconnect(Long oauthId) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        JSONObject response = webClient.post()
+                .uri(uriBuilder -> uriBuilder.path("/v1/user/unlink").build())
+                .header("Authorization", "KakaoAK " + KAKAO_SERVICE_APP_ADMIN_KEY)
+                .body(Mono.just(
+                        Map.of("target_id_type", "user_id",
+                                "target_id", oauthId)), JSONObject.class)
+                .retrieve().bodyToMono(JSONObject.class).block();
+
+        log.info("kakaoMemberDisconnect response: " + response.toString());
+
     }
 
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoProvider.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class KakaoMemberProvider {
+public class KakaoProvider {
     private final AuthJwtParser authJwtParser;
     private final PublicKeyGenerator publicKeyGenerator;
     private final KakaoClient kakaoClient;

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -41,6 +41,7 @@ public class AuthService {
     }
 
     public void socialServiceSignOut(Long userId, AuthPlatform authPlatform) {
+        log.info("socialServiceSignOut userId : " + userId + " authPlatform : " + authPlatform);
         switch (authPlatform) {
             case KAKAO:
                 authRepository.findByUserId(userId).ifPresent(auth -> {

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -41,11 +41,10 @@ public class AuthService {
     }
 
     public void socialServiceSignOut(Long userId, AuthPlatform authPlatform) {
-        log.info("socialServiceSignOut userId : " + userId + " authPlatform : " + authPlatform);
         switch (authPlatform) {
             case KAKAO:
                 authRepository.findByUserId(userId).ifPresent(auth -> {
-                    kakaoProvider.kakaoMemberSignOut(auth.getOauthId());
+                    kakaoProvider.kakaoMemberSignOut(auth.getOauthPlatformId());
                 });
                 break;
             default:
@@ -61,7 +60,7 @@ public class AuthService {
                         () -> new AuthException(AuthExceptionErrorCode.AUTH_INFO_NOT_FOUND,
                                 "해당 사용자의 소셜로그인 정보가 존재하지 않습니다.")
                 );
-                kakaoProvider.kakaoMemberDisconnect(auth.getOauthId());
+                kakaoProvider.kakaoMemberDisconnect(auth.getOauthPlatformId());
                 break;
             default:
                 throw new AuthException(AuthExceptionErrorCode.NOT_SUPPORTED_AUTH_PLATFORM,

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -1,6 +1,9 @@
 package com.swyp3.babpool.infra.auth.service;
 
+import com.swyp3.babpool.infra.auth.AuthPlatform;
 import com.swyp3.babpool.infra.auth.domain.Auth;
+import com.swyp3.babpool.infra.auth.exception.AuthException;
+import com.swyp3.babpool.infra.auth.exception.errorcode.AuthExceptionErrorCode;
 import com.swyp3.babpool.infra.auth.kakao.KakaoProvider;
 import com.swyp3.babpool.infra.auth.dao.AuthRepository;
 import com.swyp3.babpool.infra.auth.kakao.KakaoTokenProvider;
@@ -28,5 +31,38 @@ public class AuthService {
 
     public void save(Auth auth) {
         authRepository.save(auth);
+    }
+
+    public AuthPlatform getAuthPlatformByUserId(Long userId) {
+        return authRepository.findByUserId(userId).orElseThrow(
+                () -> new AuthException(AuthExceptionErrorCode.AUTH_INFO_NOT_FOUND,
+                        "해당 사용자의 소셜로그인 정보가 존재하지 않습니다.")
+        ).getOauthPlatformName();
+    }
+
+    public void socialServiceSignOut(Long userId, AuthPlatform authPlatform) {
+        switch (authPlatform) {
+            case KAKAO:
+                kakaoProvider.kakaoMemberSignOut(userId);
+                break;
+            default:
+                throw new AuthException(AuthExceptionErrorCode.NOT_SUPPORTED_AUTH_PLATFORM,
+                        "지원하지 않는 소셜로그인 플랫폼입니다.");
+        }
+    }
+
+    public void socialServiceDisconnect(Long userId, AuthPlatform authPlatform) {
+        switch (authPlatform) {
+            case KAKAO:
+                Auth auth = authRepository.findByUserId(userId).orElseThrow(
+                        () -> new AuthException(AuthExceptionErrorCode.AUTH_INFO_NOT_FOUND,
+                                "해당 사용자의 소셜로그인 정보가 존재하지 않습니다.")
+                );
+                kakaoProvider.kakaoMemberDisconnect(auth.getOauthId());
+                break;
+            default:
+                throw new AuthException(AuthExceptionErrorCode.NOT_SUPPORTED_AUTH_PLATFORM,
+                        "지원하지 않는 소셜로그인 플랫폼입니다.");
+        }
     }
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -51,8 +51,8 @@ public class AuthService {
         }
     }
 
-    public void socialServiceDisconnect(Long userId, AuthPlatform authPlatform) {
-        switch (authPlatform) {
+    public void socialServiceDisconnect(Long userId, AuthPlatform authPlatformName) {
+        switch (authPlatformName) {
             case KAKAO:
                 Auth auth = authRepository.findByUserId(userId).orElseThrow(
                         () -> new AuthException(AuthExceptionErrorCode.AUTH_INFO_NOT_FOUND,

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -43,7 +43,9 @@ public class AuthService {
     public void socialServiceSignOut(Long userId, AuthPlatform authPlatform) {
         switch (authPlatform) {
             case KAKAO:
-                kakaoProvider.kakaoMemberSignOut(userId);
+                authRepository.findByUserId(userId).ifPresent(auth -> {
+                    kakaoProvider.kakaoMemberSignOut(auth.getOauthId());
+                });
                 break;
             default:
                 throw new AuthException(AuthExceptionErrorCode.NOT_SUPPORTED_AUTH_PLATFORM,

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.swyp3.babpool.infra.auth.service;
 
 import com.swyp3.babpool.infra.auth.domain.Auth;
-import com.swyp3.babpool.infra.auth.kakao.KakaoMemberProvider;
+import com.swyp3.babpool.infra.auth.kakao.KakaoProvider;
 import com.swyp3.babpool.infra.auth.dao.AuthRepository;
 import com.swyp3.babpool.infra.auth.kakao.KakaoTokenProvider;
 import com.swyp3.babpool.infra.auth.response.AuthMemberResponse;
@@ -15,13 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class AuthService {
-    private final KakaoMemberProvider kakaoMemberProvider;
+    private final KakaoProvider kakaoProvider;
     private final KakaoTokenProvider kakaoTokenProvider;
     private final AuthRepository authRepository;
 
     public AuthMemberResponse getUserDataByCode(String code) {
         String idToken = kakaoTokenProvider.getIdTokenFromKakao(code);
-        AuthMemberResponse kakaoPlatformMember = kakaoMemberProvider.getKakaoPlatformMember(idToken);
+        AuthMemberResponse kakaoPlatformMember = kakaoProvider.getKakaoPlatformMember(idToken);
 
         return kakaoPlatformMember;
     }

--- a/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
+++ b/src/main/java/com/swyp3/babpool/infra/health/api/HealthCheckApi.java
@@ -1,13 +1,16 @@
 package com.swyp3.babpool.infra.health.api;
 
 import com.swyp3.babpool.domain.user.domain.UserRole;
+import com.swyp3.babpool.global.common.response.ApiResponse;
 import com.swyp3.babpool.global.common.response.ApiResponseWithCookie;
+import com.swyp3.babpool.global.common.response.CookieProvider;
 import com.swyp3.babpool.global.jwt.application.JwtService;
 import com.swyp3.babpool.global.jwt.application.response.JwtPairDto;
 import com.swyp3.babpool.global.uuid.application.UuidService;
 import com.swyp3.babpool.infra.health.application.HealthCheckService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -73,8 +76,11 @@ public class HealthCheckApi {
     }
 
     @GetMapping("/api/test/cookie")
-    public ApiResponseWithCookie<String> testCookie() {
-        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK, "success", "data", "refreshToken1234");
+    public ResponseEntity<ApiResponse<String>> testCookie() {
+//        return ApiResponseWithCookie.ofRefreshToken(HttpStatus.OK, "success", "data", "refreshToken1234");
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken("refreshToken1234", 1).toString())
+                .body(ApiResponse.ok("data"));
     }
 
 }

--- a/src/main/resources/mapper/AuthMapper.xml
+++ b/src/main/resources/mapper/AuthMapper.xml
@@ -3,6 +3,10 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.swyp3.babpool.infra.auth.dao.AuthRepository">
 
+    <select id="findByUserId" parameterType="long" resultType="com.swyp3.babpool.infra.auth.domain.Auth">
+        select * from t_oauth where user_id = #{userId}
+    </select>
+
     <insert id="save" useGeneratedKeys="true" keyProperty="oauthId">
         insert into t_oauth(user_id,oauth_platform_name,oauth_platform_id)
         values ( #{userId},#{oauthPlatformName},#{oauthPlatformId} )

--- a/src/main/resources/mapper/ExitInfoMapper.xml
+++ b/src/main/resources/mapper/ExitInfoMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.swyp3.babpool.domain.user.dao.ExitInfoRepository">
+
+    <insert id="saveExitInfo" useGeneratedKeys="true" keyProperty="exitInfoId">
+        insert into t_exit_info(user_id,exit_reason,exit_date)
+        values ( #{userId},#{exitReason}, CURRENT_TIMESTAMP() )
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/ExitInfoMapper.xml
+++ b/src/main/resources/mapper/ExitInfoMapper.xml
@@ -3,7 +3,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.swyp3.babpool.domain.user.dao.ExitInfoRepository">
 
-    <insert id="saveExitInfo" useGeneratedKeys="true" keyProperty="exitInfoId">
+    <insert id="saveExitInfo">
         insert into t_exit_info(user_id,exit_reason,exit_date)
         values ( #{userId},#{exitReason}, CURRENT_TIMESTAMP() )
     </insert>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -58,4 +58,10 @@
         WHERE user_id=#{userId}
     </select>
 
+    <update id="updateUserStateByUserId">
+        update t_user_account
+        set user_status = #{userStatus}
+        where user_id = #{userId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
Resolves #92 #93
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 로그아웃 및 회원탈퇴 기능이 추가되었습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 카카오 서버와 통신을 하기 위한 도구로 WebClient 를 선정했고, 이를 위해 webflux 를 추가했습니다.
   - [KakaoProvider.java](https://github.com/swyp3-babpool/babpool-backend/pull/98/files#diff-288edb1658cf0881663992b5e670c7b67583ce75d979efd6751cd271427719b6) 파일에 카카오 서비스로부터 로그아웃을 담당하는 `kakaoMemberSignOut` 메서드와 밥풀서비스와 카카오 서비스의 연결끊기를 담당하는 `kakaoMemberDisconnect` 메서드를 추가하였고 로컬환경에서 정상 동작하는 것을 확인했습니다.
- 기존 쿠키 저장 방식이 올바르게 브라우저에 전달되지 않는 것으로 파악되어, 쿠키를 응답하는 API에서만 `ResponseEntity<ApiResponse<>>`를 사용하도록 변경했습니다.
   - 기존 코드는 주석처리했습니다. 운영서버에서 정상 동작하는 것을 확인 후 삭제될 예정입니다.
   - Controller가 쿠키 설정값들을 의존하고 있지 않기 위해 별도의 [CookieProvider.java](https://github.com/swyp3-babpool/babpool-backend/pull/98/files#diff-f1b59c3e3fbfe0b635bfc6ac4abee57c3fd7982531729bf158fc8a3f913b10ba)를 생성했습니다.
   - 운영서버에서 정상 동작하는 것을 확인 후 ApiResopnseWIthCookie 클래스는 삭제될 예정입니다.
- 

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- yml 파일이 변경됨에 따라 깃헙 시크릿에 인코딩된 설정파일을 재 업로드 하겠습니다.

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->