### PR TITLE
feat(profile): Add active flag update query in profileMaper

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -173,10 +173,10 @@ public class AppointmentServiceImpl implements AppointmentService{
     }
 
     private void updateProfileActiveFlagIfPossibleDateNoExistAnymore(Appointment appointment) {
-        // 해당 사용자의 활성화된 시간을 확인 후, 활성화된 시간이 없으면
-        if(appointmentRepository.findAppointmentPossibleDateTimeByProfileId(appointment.getAppointmentRequesterUserId()).isEmpty()){
+        // 해당 사용자(수락자)의 활성화된 시간을 확인 후, 활성화된 시간이 없으면
+        if(appointmentRepository.findAppointmentPossibleDateTimeByProfileId(appointment.getAppointmentReceiverUserId()).isEmpty()){
             // 해당 사용자의 profile_active_flag 값을 0으로 변경
-            int updatedRows = profileRepository.updateProfileActiveFlag(appointment.getAppointmentRequesterUserId(), false);
+            int updatedRows = profileRepository.updateProfileActiveFlag(appointment.getAppointmentReceiverUserId(), false);
             if(updatedRows == 0){
                 throw new AppointmentException(AppointmentErrorCode.PROFILE_ACTIVE_FLAG_UPDATE_FAILED, "프로필 활성화 상태 변경에 실패했습니다.");
             }

--- a/src/main/java/com/swyp3/babpool/domain/profile/dao/ProfileRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/dao/ProfileRepository.java
@@ -67,5 +67,5 @@ public interface ProfileRepository {
     ProfileDefault findProfileDefault(Long profileId);
     Boolean findProfileIsRegistered(Long profileId);
 
-    int updateProfileActiveFlag(Long appointmentRequesterUserId, Boolean activeFlag);
+    int updateProfileActiveFlag(@Param("userId") Long userId, @Param("activeFlag") Boolean activeFlag);
 }

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
@@ -30,7 +30,7 @@ public class UserApi {
      * 로그인 요청 api
      */
     @PostMapping("/sign/in")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO loginRequest){
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequestDTO loginRequest){
         LoginResponseWithRefreshToken loginResponseData = userService.login(loginRequest);
         Boolean isRegistered = loginResponseData.getLoginResponse().getIsRegistered();
 
@@ -57,7 +57,7 @@ public class UserApi {
     return ResponseEntity
             .status(HttpStatus.OK)
             .header(HttpHeaders.SET_COOKIE, CookieProvider.ofRefreshToken(loginResponseData.getRefreshToken()).toString())
-            .body(ApiResponse.ok(loginResponseData.getLoginResponseDTO()));
+            .body(ApiResponse.ok(loginResponseData.getLoginResponse()));
     }
 
     /**

--- a/src/main/resources/mapper/ProfileMapper.xml
+++ b/src/main/resources/mapper/ProfileMapper.xml
@@ -235,4 +235,10 @@
         WHERE profile_id=#{profileId}
     </select>
 
+    <update id="updateProfileActiveFlag">
+        UPDATE t_profile
+        SET profile_active_flag = #{activeFlag}
+        WHERE user_id = #{userId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- ProfileMapper.xml 에 `updateProfileActiveFlag` 메서드가 누락되어 있음

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 사용자 프로필 활성화 여부를 변경하는 쿼리메서드를 추가했습니다


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- @yeonjookang `LoginResponseDTO` 타입이 정의되어 있지 않아서 [UserApi.java](https://github.com/swyp3-babpool/babpool-backend/pull/120/files#diff-d5c3f7acdb87c3390b7e64e2e11ffb45da0dbfb45836753e447f93611a560fa6) 에서 컴파일 에러가 발생하고 있었습니다. 우선 `LoginResponse`으로 재수정해서 PR 생성했습니다! 변경이 필요하신게 맞다면 다음 PR에서 수정해주세요 :)

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->