### PR TITLE
Hotfix/pro hyundo

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.0.18)
+name: Spring Boot Gradle CICD (version 0.0.19)
 
 on:
   push:

--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
@@ -59,7 +59,7 @@ public class AppointmentApi {
     }
 
     /**
-     * 밥약 히스토리 - 거절(EXPIRE, REJECT) 리스트 조회 API
+     * 밥약 히스토리 - 거절(EXPIRE, REJECT)당한 리스트 조회 API
      */
     @GetMapping("/api/appointment/list/refuse")
     public ApiResponse<List<AppointmentHistoryRefuseResponse>> getRefuseAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -110,7 +110,7 @@ public class AppointmentServiceImpl implements AppointmentService{
     public List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long receiverUserId) {
         List<AppointmentHistoryRefuseResponse> historyRefuseResponseList = appointmentRepository.findRefuseAppointmentListByReceiverId(receiverUserId);
         if (historyRefuseResponseList.isEmpty()) {
-            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_REFUSE_NOT_FOUND, "거절된 밥약이 존재하지 않습니다.");
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_REFUSE_NOT_FOUND, "거절당한 밥약이 존재하지 않습니다.");
         }
         return historyRefuseResponseList;
     }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -46,6 +46,11 @@ public class AppointmentServiceImpl implements AppointmentService{
     @Transactional
     @Override
     public AppointmentCreateResponse makeAppointment(AppointmentCreateRequest appointmentCreateRequest) {
+        // is requesterUserId same as receiverUserId?
+        if(appointmentCreateRequest.getRequesterUserId().equals(appointmentCreateRequest.getTargetProfileId())){
+            throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_REQUESTER_IS_SAME_AS_RECEIVER, "본인에게 밥약을 요청할 수 없습니다.");
+        }
+
         // 프로필 카드 식별 번호로, 타겟(요청받을) 사용자 내부 식별 값 조회.
         Long targetReceiverUserId = profileRepository.findUserIdByProfileId(appointmentCreateRequest.getTargetProfileId());
         appointmentCreateRequest.setReceiverUserId(targetReceiverUserId);

--- a/src/main/java/com/swyp3/babpool/domain/appointment/exception/errorcode/AppointmentErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/exception/errorcode/AppointmentErrorCode.java
@@ -20,7 +20,9 @@ public enum AppointmentErrorCode implements CustomErrorCode {
     APPOINTMENT_NOT_REQUESTER(HttpStatus.BAD_REQUEST,"밥약 요청을 취소할 권한이 없습니다."),
     APPOINTMENT_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"밥약 요청 취소에 실패하였습니다."),
     PROFILE_ACTIVE_FLAG_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 활성화 상태 변경에 실패하였습니다."),
-    APPOINTMENT_DETAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "밥약 상세 조회에 실패하였습니다.");
+    APPOINTMENT_DETAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "밥약 상세 조회에 실패하였습니다."),
+    APPOINTMENT_REQUESTER_IS_SAME_AS_RECEIVER(HttpStatus.BAD_REQUEST, "밥약 요청자와 수신자가 동일합니다."),
+    ;
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/profile/application/ProfileServiceImpl.java
@@ -291,17 +291,19 @@ public class ProfileServiceImpl implements ProfileService{
         if(!insertTargets.isEmpty()){
             // Map 순회하며 추가 : 추가할 때는 날짜 먼저 추가
             insertTargets.forEach((date, timeList) -> {
-                boolean isAlreadyExistDate = possibleDateTimeRepository.checkExistPossibleDate(profileId, date);
-                if (isAlreadyExistDate) {
-                    log.info("ProfileServiceImpl.updatePossibleDateTime, 이미 존재하는 가능한 날짜입니다. {}", date);
-                    return;
-                }
                 PossibleDateInsertDto possibleDateInsertDto = PossibleDateInsertDto.builder()
                         .profileId(profileId)
                         .date(date)
                         .build();
+                // 이미 존재하는 날짜라면 날짜를 추가하지는 않음.
+                boolean isAlreadyExistDate = possibleDateTimeRepository.checkExistPossibleDate(profileId, date);
+                if (!isAlreadyExistDate) {
+                    possibleDateTimeRepository.insertPossibleDate(possibleDateInsertDto);
+                }else{
+                    log.info("ProfileServiceImpl.updatePossibleDateTime, 이미 존재하는 가능한 날짜입니다. {}", date);
+                }
 
-                possibleDateTimeRepository.insertPossibleDate(possibleDateInsertDto);
+                // 추가 대상인 시간을 순회하면서
                 for (Integer time : timeList) {
                     boolean isAlreadyExistTime = possibleDateTimeRepository.checkExistPossibleTime(profileId, date, time);
                     if (isAlreadyExistTime) {

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -140,7 +140,7 @@
                 inner join t_profile profile on appoint.appointment_requester_id = profile.user_id
                 inner join t_user_account account on appoint.appointment_requester_id = account.user_id
                 left join t_reject reject on appoint.appointment_id = reject.appointment_id
-          where appoint.appointment_requester_id = #{receiverUserId}
+          where appoint.appointment_receiver_id = #{receiverUserId}
              and appoint.appointment_status IN ('REJECT', 'EXPIRE')
     </select>
 


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
1. 새로 추가된 날짜가 이미 사용자가 활성화 해둔 날짜인 경우, 새로 추가된 시간이 추가되지 않는 오류가 있었습니다.
2. 사용자가 거절당한 밥약 페이지에 거절당한 요청이 정상적으로 조회되지 않았습니다.
3. 밥약 요청시, 프론트의 유효성 검사를 우회해, 자기 자신에게 밥약 요청ㅇ

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
1. 이미 존재하는 날짜이더라도, 추가된 시간이 있으면 추가되도록 로직을 변경했습니다.
   - 날짜가 이미 존재하면 `return` 문을 사용한 것이 원인이었습니다.

2. 잘못된 컬럼명을 조건에 사용한 것이 원인이었습니다.
   - `appointmentRepository.findRefuseAppointmentListByReceiverId(receiverUserId)` 쿼리를 점검한 결과 `appointment_receiver_id`를 조건 컬럼으로 사용해야 하는데 `appointment_requester_id`로 되어 있었습니다.

4. 

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->