### PR TITLE
fix: refused history and appointment list orderby

### DIFF
--- a/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/api/AppointmentApi.java
@@ -62,8 +62,8 @@ public class AppointmentApi {
      * 밥약 히스토리 - 거절(EXPIRE, REJECT)당한 리스트 조회 API
      */
     @GetMapping("/api/appointment/list/refuse")
-    public ApiResponse<List<AppointmentHistoryRefuseResponse>> getRefuseAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {
-        return ApiResponse.ok(appointmentService.getRefuseAppointmentList(userId));
+    public ApiResponse<List<AppointmentHistoryRefuseResponse>> getRefusedAppointmentList(@RequestAttribute(value = "userId", required = false) Long userId) {
+        return ApiResponse.ok(appointmentService.getRefusedAppointmentList(userId));
     }
 
     /**

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentService.java
@@ -17,7 +17,7 @@ public interface AppointmentService {
 
     List<AppointmentHistoryDoneResponse> getDoneAppointmentList(Long userId);
 
-    List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long userId);
+    List<AppointmentHistoryRefuseResponse> getRefusedAppointmentList(Long userId);
 
     List<AppointmentPossibleDateTimeResponse> getAppointmentPossibleDateTime(Long profileId);
 

--- a/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/application/AppointmentServiceImpl.java
@@ -112,8 +112,8 @@ public class AppointmentServiceImpl implements AppointmentService{
     }
 
     @Override
-    public List<AppointmentHistoryRefuseResponse> getRefuseAppointmentList(Long receiverUserId) {
-        List<AppointmentHistoryRefuseResponse> historyRefuseResponseList = appointmentRepository.findRefuseAppointmentListByReceiverId(receiverUserId);
+    public List<AppointmentHistoryRefuseResponse> getRefusedAppointmentList(Long requesterUserId) {
+        List<AppointmentHistoryRefuseResponse> historyRefuseResponseList = appointmentRepository.findRefuseAppointmentListByRequesterId(requesterUserId);
         if (historyRefuseResponseList.isEmpty()) {
             throw new AppointmentException(AppointmentErrorCode.APPOINTMENT_REFUSE_NOT_FOUND, "거절당한 밥약이 존재하지 않습니다.");
         }

--- a/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/appointment/dao/AppointmentRepository.java
@@ -23,7 +23,7 @@ public interface AppointmentRepository {
 
     List<AppointmentHistoryDoneResponse> findDoneAppointmentListByRequesterId(Long requesterUserId);
 
-    List<AppointmentHistoryRefuseResponse> findRefuseAppointmentListByReceiverId(Long receiverUserId);
+    List<AppointmentHistoryRefuseResponse> findRefuseAppointmentListByRequesterId(Long requesterUserId);
 
     List<AppointmentPossibleDateTimeResponse> findAppointmentPossibleDateTimeByProfileId(Long profileId);
 

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -131,7 +131,7 @@
     </select>
 
     <!--  밥약 히스토리 - 거절 당한 요청 리스트  -->
-    <select id="findRefuseAppointmentListByReceiverId" resultMap="appointmentHistoryRefuseResponse">
+    <select id="findRefuseAppointmentListByRequesterId" resultMap="appointmentHistoryRefuseResponse">
         select appoint.appointment_id,
                profile.profile_id,
                account.user_nick_name,
@@ -142,8 +142,9 @@
                 inner join t_profile profile on appoint.appointment_requester_id = profile.user_id
                 inner join t_user_account account on appoint.appointment_requester_id = account.user_id
                 left join t_reject reject on appoint.appointment_id = reject.appointment_id
-          where appoint.appointment_requester_id = #{requesterUserId}
-             and appoint.appointment_status IN ('REJECT', 'EXPIRE')
+        where appoint.appointment_requester_id = #{requesterUserId}
+            and appoint.appointment_status IN ('REJECT', 'EXPIRE')
+        ORDER BY reject.reject_create_date DESC;
     </select>
 
     <select id="findAppointmentPossibleDateTimeByProfileId" parameterType="long" resultType="com.swyp3.babpool.domain.appointment.application.response.AppointmentPossibleDateTimeResponse">

--- a/src/main/resources/mapper/AppointmentMapper.xml
+++ b/src/main/resources/mapper/AppointmentMapper.xml
@@ -53,6 +53,7 @@
         WHERE
             appoint.appointment_requester_id = #{requesterUserId}
         AND appoint.appointment_status IN ('WAITING', 'ACCEPT')
+        ORDER BY appoint.appointment_create_date DESC;
     </select>
 
     <!--  밥약 알림 - 특정 사용자가 받은 밥약 알림  -->
@@ -76,6 +77,7 @@
         WHERE
             appoint.appointment_receiver_id = #{receiverUserId}
         AND appoint.appointment_status IN ('WAITING', 'ACCEPT')
+        ORDER BY appoint.appointment_create_date DESC;
     </select>
 
     <select id="countAcceptedAppointmentByReceiverIdAndPossibleTimeId" resultType="int" parameterType="map">
@@ -140,7 +142,7 @@
                 inner join t_profile profile on appoint.appointment_requester_id = profile.user_id
                 inner join t_user_account account on appoint.appointment_requester_id = account.user_id
                 left join t_reject reject on appoint.appointment_id = reject.appointment_id
-          where appoint.appointment_receiver_id = #{receiverUserId}
+          where appoint.appointment_requester_id = #{requesterUserId}
              and appoint.appointment_status IN ('REJECT', 'EXPIRE')
     </select>
 


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
1) 밥약 히스토리에서 응답되는 데이터가 반대로 되어 있다. 거절당한게 나와야 하는데, 내가 거절한게 응답된다.

2)밥약 알림 - 알림 리스트 응답할 때 쿼리에 ASC DESC 다시 확인, 최근 생성일 순으로 응답해야함

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
1) 쿼리 수정 완료
2) 쿼리에 ORDER BY 속성 추가 완료


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->