### PR TITLE
Fix: change path of log file

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.1.3)
+name: Spring Boot Gradle CICD (version 0.1.4)
 
 on:
   push:
@@ -128,6 +128,25 @@ jobs:
           key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
           source: "app.conf"
           target: "/home/ubuntu/data/nginx/conf"
+
+      - name: Create promtail-config.yml from secrets
+        run: |
+          touch ./promtail-config.yml
+          echo -e "${{secrets.PROMTAIL_CONFIG}}" | base64 --decode > ./promtail-config.yml
+      - name: Upload promtail-config.yml to Repo
+        uses: actions/upload-artifact@v3
+        with:
+          name: promtail-config.yml
+          path: ./promtail-config.yml
+          retention-days: 1
+      - name: Copy promtail-config.yml to VM
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VM_HOST_IP }}
+          username: ${{ secrets.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          source: "promtail-config.yml"
+          target: "/home/ubuntu"
 
       - name: executing remote ssh commands using password
         uses: appleboy/ssh-action@v1.0.0

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <property name="LOG_PATH" value="/var/logs" />
+    <property name="LOG_PATH" value="./var/log" />
 <!--    <property name="LOG_FILE" value="${LOG_PATH}/spring-boot-logger.log" />-->
     <property name="CUSTOM_FILE_LOG_PATTERN" value="%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}} %5p ${PID:- } --- [%15.15t] [%X{request_uuid}] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
 


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
![image](https://github.com/swyp3-babpool/babpool-backend/assets/128882585/3069247e-5f5b-4874-9d5a-9487333ad4ed)
- github actions build 과정에서 다음과 같이 `/var/logs` 경로에 파일을 생성하지 못하는 오류가 발생 

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- github actions는 runners docker 컨테이너 기반으로 동작한다.
- 절대경로를 사용했기 때문에 권한 문제로 해당 경로에 파일을 생성하지 못한것으로 추정해 상대경로로 path를 변경했다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->