### PR TITLE
fix: URL 패턴에 asterisk를 사용한 경우 매칭이 안되는 문제 해결

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.1.5)
+name: Spring Boot Gradle CICD (version 0.1.6)
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ out/
 docker-compose.yaml
 nginx/app.conf
 
+### LOGGING ###
+var/
+
 ### NetBeans ###
 /nbproject/private/
 /nbbuild/


### PR DESCRIPTION
Resolves #없음
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- URL 패턴에 asterisk를 사용한 경우 매칭이 안되는 문제

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `AntPathMatcher` 를 사용해 URL 패턴에 `*` 이 들어간 경우도 매칭시킬 수 있도록 해결


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->