### PR TITLE
fix(kakao): 로컬환경에서 카카오로그인이 안되는 이슈 해결

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.1.7)
+name: Spring Boot Gradle CICD (version 0.1.8)
 
 on:
   push:

--- a/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/api/UserApi.java
@@ -30,8 +30,8 @@ public class UserApi {
      * 로그인 요청 api
      */
     @PostMapping("/sign/in")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequestDTO loginRequest){
-        LoginResponseWithRefreshToken loginResponseData = userService.login(loginRequest);
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequestDTO loginRequest, @RequestAttribute(value = "localhostFlag", required = false) String localhostFlag){
+        LoginResponseWithRefreshToken loginResponseData = userService.login(loginRequest, localhostFlag);
         Boolean isRegistered = loginResponseData.getLoginResponse().getIsRegistered();
 
         //로그인 성공한 경우

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserService.java
@@ -7,7 +7,7 @@ import com.swyp3.babpool.domain.user.application.response.MyPageResponse;
 import com.swyp3.babpool.domain.user.application.response.UserGradeResponse;
 
 public interface UserService {
-    LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest);
+    LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest, String localhostFlag);
     LoginResponseWithRefreshToken signUp(SignUpRequestDTO signUpRequest);
 
     void signDown(Long userId, String exitReason, String refreshTokenFromCookie);

--- a/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/user/application/UserServiceImpl.java
@@ -47,8 +47,8 @@ public class UserServiceImpl implements UserService{
     private final ExitInfoRepository exitInfoRepository;
 
     @Override
-    public LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest) {
-        AuthMemberResponse kakaoPlatformMember = authService.getUserDataByCode(loginRequest.getCode());
+    public LoginResponseWithRefreshToken login(LoginRequestDTO loginRequest, String localhostFlag) {
+        AuthMemberResponse kakaoPlatformMember = authService.getUserDataByCode(loginRequest.getCode(), localhostFlag);
         return generateLoginResponse(AuthPlatform.KAKAO,kakaoPlatformMember);
     }
 

--- a/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoTokenProvider.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/kakao/KakaoTokenProvider.java
@@ -25,8 +25,9 @@ public class KakaoTokenProvider {
     @Value("${property.oauth.kakao.client-secret}")
     private String clientSecret;
 
-    public String getIdTokenFromKakao(String code) {
+    public String getIdTokenFromKakao(String code, String localhostFlag) {
         String idToken;
+        reAssignKakaoRedirectUriWhenRequestFromLocalHost(localhostFlag);
 
         try {
             URL url = new URL(reqURL);
@@ -85,5 +86,9 @@ public class KakaoTokenProvider {
             throw new AuthException(AuthExceptionErrorCode.AUTH_ERROR_CONNECT_WITH_KAKAO,
                     e.getMessage().toString());
         }
+    }
+
+    private void reAssignKakaoRedirectUriWhenRequestFromLocalHost(String localhostFlag) {
+        redirectUri = localhostFlag != null && localhostFlag.equals("true") ? "http://localhost:5173/auth/kakao/callback" : redirectUri;
     }
 }

--- a/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
+++ b/src/main/java/com/swyp3/babpool/infra/auth/service/AuthService.java
@@ -24,8 +24,8 @@ public class AuthService {
     private final KakaoTokenProvider kakaoTokenProvider;
     private final AuthRepository authRepository;
 
-    public AuthMemberResponse getUserDataByCode(String code) {
-        String idToken = kakaoTokenProvider.getIdTokenFromKakao(code);
+    public AuthMemberResponse getUserDataByCode(String code, String localhostFlag) {
+        String idToken = kakaoTokenProvider.getIdTokenFromKakao(code, localhostFlag);
         AuthMemberResponse kakaoPlatformMember = kakaoProvider.getKakaoPlatformMember(idToken);
 
         return kakaoPlatformMember;

--- a/src/test/java/com/swyp3/babpool/global/logging/MdcLoggingFilterTest.java
+++ b/src/test/java/com/swyp3/babpool/global/logging/MdcLoggingFilterTest.java
@@ -91,4 +91,15 @@ class MdcLoggingFilterTest {
         log.info("output >> {}", output.getAll());
     }
 
+    @DisplayName("origin 이 LOCAL_HOST_5173 인 경우, request 에 localhostFlag=true 속성을 추가한다.")
+    @Test
+    void setOriginAttributeAtRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("origin", "http://localhost:5173");
+
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        mdcLoggingFilter.setOriginAttributeAtRequest(requestWrapper);
+
+        assertThat(requestWrapper.getAttribute("localhostFlag")).isEqualTo("true");
+    }
 }

--- a/src/test/java/com/swyp3/babpool/infra/auth/kakao/KakaoTokenProviderTest.java
+++ b/src/test/java/com/swyp3/babpool/infra/auth/kakao/KakaoTokenProviderTest.java
@@ -1,0 +1,40 @@
+package com.swyp3.babpool.infra.auth.kakao;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class KakaoTokenProviderTest {
+
+    private String redirectUri = "https://bab-pool.com/auth/kakao/callback";
+
+    @Test
+    void resolveKakaoRedirectUriWhenRequestFromLocalHost() {
+        // given
+        String localhostFlag = "true";
+
+        // when
+        reAssignKakaoRedirectUriWhenRequestFromLocalHost(localhostFlag);
+
+        // then
+        assertEquals("http://localhost:5173/auth/kakao/callback", redirectUri);
+    }
+
+    @Test
+    void resolveKakaoRedirectUriWhenRequestFromNotLocalHost() {
+        // given
+        String localhostFlag = null;
+
+        // when
+        reAssignKakaoRedirectUriWhenRequestFromLocalHost(localhostFlag);
+
+        // then
+        assertEquals("https://bab-pool.com/auth/kakao/callback", redirectUri);
+    }
+
+    private void reAssignKakaoRedirectUriWhenRequestFromLocalHost(String localhostFlag) {
+        redirectUri = localhostFlag != null && localhostFlag.equals("true") ? "http://localhost:5173/auth/kakao/callback" : redirectUri;
+    }
+
+}


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- kakao redirect url 을 동적으로 변경하여 로컬환경에서 카카오 로그인이 안되는 이슈 해결

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 프론트 애플리케이션을 로컬환경에서 실행 후, 운영중인 백엔드 서버로 카카오 로그인을 요청할 경우, redirect url 이 로컬환경 url 으로 설정되어 있지 않아 카카오 로그인이 정상동작하지 않았습니다.
- http header 에 특정 key-value 를 담아 백엔드 서버로 요청할 경우, 동적으로 redirect url 을 로컬환경을 위한 url 으로 설정되도록 하여 이슈를 해결했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->