### PR TITLE
update(filter): 커스텀 헤더 변경 반영

### DIFF
--- a/src/main/java/com/swyp3/babpool/global/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/swyp3/babpool/global/logging/MdcLoggingFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -31,7 +32,9 @@ public class MdcLoggingFilter extends OncePerRequestFilter{
     private static ArrayList<String> MONITORING_ALLOWED_IPS = new ArrayList<>(Arrays.asList(
             "34.168.207.216"
     ));
-    private static final String LOCAL_HOST_5173 = "http://localhost:5173";
+
+    @Value("${property.header.x-babpool-local-front}")
+    private String X_BABPOOL_LOCAL_FRONT_VALUE;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -66,8 +69,8 @@ public class MdcLoggingFilter extends OncePerRequestFilter{
      * @param requestWrapper
      */
     void setOriginAttributeAtRequest(ContentCachingRequestWrapper requestWrapper) {
-        String requestOrigin = requestWrapper.getHeader("origin");
-        if (StringUtils.hasText(requestOrigin) && requestOrigin.equals(LOCAL_HOST_5173)) {
+        String requestOrigin = requestWrapper.getHeader("x-babpool-local-front");
+        if (StringUtils.hasText(requestOrigin) && requestOrigin.equals(X_BABPOOL_LOCAL_FRONT_VALUE)) {
             requestWrapper.setAttribute("localhostFlag", "true");
         }
     }


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 로컬에서 카카오 로그인 요청 시, 리다이렉트 URL 을 변경하기 위한 커스텀 헤더 속성 반영

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- "Origin" 헤더 속성에서 "x-babpool-local-front" 커스텀 헤더 속성을 사용하도록 변경했습니다.
- 'x-babpool-local-front' 헤더로 특정 값이 요청될 경우 'localhostFlag' 값을 'true' 으로 설정
- 로컬에서 요청했음을 확인하는데 사용된느 value는 코드레벨이 아닌 설정파일을 통해 세팅되도록 변경했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->