### PR TITLE
feat: JSON 직렬화 및 스웨거 에러 응답 생성

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.2.0)
+name: Spring Boot Gradle CICD (version 0.2.1)
 
 on:
   push:

--- a/src/main/java/com/swyp3/babpool/global/config/JsonResponseLongToStringConfig.java
+++ b/src/main/java/com/swyp3/babpool/global/config/JsonResponseLongToStringConfig.java
@@ -1,0 +1,17 @@
+package com.swyp3.babpool.global.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+
+@JsonComponent
+public class JsonResponseLongToStringConfig extends JsonSerializer<Long>{
+
+    @Override
+    public void serialize(Long idLong, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeString(String.valueOf(idLong));
+    }
+}

--- a/src/main/java/com/swyp3/babpool/global/swagger/SwaggerAccessInterceptor.java
+++ b/src/main/java/com/swyp3/babpool/global/swagger/SwaggerAccessInterceptor.java
@@ -4,6 +4,8 @@ import com.swyp3.babpool.domain.user.domain.UserRole;
 import com.swyp3.babpool.global.jwt.JwtAuthenticator;
 import com.swyp3.babpool.global.jwt.exception.BabpoolJwtException;
 import com.swyp3.babpool.global.jwt.exception.errorcode.JwtExceptionErrorCode;
+import com.swyp3.babpool.global.swagger.exception.SwaggerErrorCode;
+import com.swyp3.babpool.global.swagger.exception.SwaggerException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +31,7 @@ public class SwaggerAccessInterceptor implements HandlerInterceptor {
 
         // 쿠키가 존재하지 않을 경우
         if(request.getCookies() == null || request.getCookies().length == 0){
-            throw new IllegalAccessException("쿠키가 존재하지 않습니다.");
+            throw new SwaggerException(SwaggerErrorCode.NOTFOUND_COOKIE, "쿠키가 Reqeust Header에 존재하지 않습니다.");
         }
 
         // refreshToken 쿠키를 찾아서 refreshToken을 가져온다.
@@ -37,7 +39,8 @@ public class SwaggerAccessInterceptor implements HandlerInterceptor {
                 .filter(cookie -> cookie.getName().equals("refreshToken"))
                 .findFirst();
         String refreshToken = refreshTokenCookie.map(Cookie::getValue).orElseThrow(
-                () -> new IllegalAccessException("쿠키에 refreshToken 이 존재하지 않습니다.")
+                () -> new SwaggerException(SwaggerErrorCode.NOTFOUND_TOKEN_IN_COOKIE,
+                        "쿠키에 refreshToken 이 존재하지 않습니다.")
         );
 
         Claims authenticate;
@@ -45,23 +48,23 @@ public class SwaggerAccessInterceptor implements HandlerInterceptor {
         try {
             authenticate = jwtAuthenticator.authenticate(refreshToken);
         }catch (Exception e){
-            throw new IllegalAccessException("토큰이 유효하지 않습니다.");
+            throw new SwaggerException(SwaggerErrorCode.INVALID_TOKEN, "토큰이 유효하지 않습니다.");
         }
 
         // 토큰이 유효하지 않을 경우
         if (authenticate == null || authenticate.isEmpty()){
-            throw new IllegalAccessException("토큰이 비어 있습니다.");
+            throw new SwaggerException(SwaggerErrorCode.INVALID_TOKEN_EMPTY, "토큰이 비어 있습니다.");
         }
 
         // 토큰의 roles가 비어있는 경우
         List<String> roles = authenticate.get("roles", List.class);
         if(roles == null || roles.isEmpty()){
-            throw new IllegalAccessException("권한을 찾을 수 없습니다.");
+            throw new SwaggerException(SwaggerErrorCode.INVALID_TOKEN_AUTHORITY, "권한을 찾을 수 없습니다.");
         }
 
         // ADMIN이 아닐 경우
         if (!roles.contains(UserRole.ADMIN.name())){
-            throw new IllegalAccessException("ADMIN 권한이 없습니다.");
+            throw new SwaggerException(SwaggerErrorCode.INVALID_TOKEN_AUTHORITY, "ADMIN 권한이 없습니다.");
         }
 
         return true;

--- a/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerErrorCode.java
+++ b/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerErrorCode.java
@@ -1,0 +1,18 @@
+package com.swyp3.babpool.global.swagger.exception;
+
+import com.swyp3.babpool.global.common.exception.errorcode.CustomErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SwaggerErrorCode implements CustomErrorCode {
+    NOTFOUND_COOKIE(HttpStatus.NOT_FOUND, "쿠키를 찾을 수 없습니다."),
+    NOTFOUND_TOKEN_IN_COOKIE(HttpStatus.NOT_FOUND, "쿠키에서 토큰을 찾을 수 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    INVALID_TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "토큰이 비어 있습니다."),
+    INVALID_TOKEN_AUTHORITY(HttpStatus.UNAUTHORIZED, "토큰의 권한이 없습니다.");
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerException.java
+++ b/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerException.java
@@ -1,0 +1,12 @@
+package com.swyp3.babpool.global.swagger.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SwaggerException extends RuntimeException{
+
+    private final SwaggerErrorCode errorCode;
+    private final String message;
+}

--- a/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerExceptionHandler.java
+++ b/src/main/java/com/swyp3/babpool/global/swagger/exception/SwaggerExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.swyp3.babpool.global.swagger.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class SwaggerExceptionHandler {
+
+//    @ExceptionHandler(SwaggerException.class)
+//    protected ResponseEntity<ApiErrorResponse> handleSwaggerException(SwaggerException exception){
+//        log.error("SwaggerException getErrorCode() >> "+exception.getErrorCode());
+//        log.error("SwaggerException getMessage() >> "+exception.getMessage());
+//        return ResponseEntity.status(exception.getErrorCode().getHttpStatus())
+//                .body(ApiErrorResponse.of(exception.getErrorCode()));
+//    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SwaggerException.class)
+    protected String handleSwaggerExceptionWithErrorPage(SwaggerException exception){
+        log.error("SwaggerException getErrorCode() >> "+exception.getErrorCode());
+        log.error("SwaggerException getMessage() >> "+exception.getMessage());
+        String html = "<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<head>\n" +
+                "    <meta charset=\"UTF-8\">\n" +
+                "    <title>Title</title>\n" +
+                "    <style>\n" +
+                "        * {transition: all 0.6s;}\n" +
+                "        html {height: 100%;}\n" +
+                "        body {font-family: 'Lato', sans-serif; color: #888; margin: 0;}\n" +
+                "        #main {display: table; width: 100%; height: 100vh; text-align: center;}\n" +
+                "        .fof {display: table-cell; vertical-align: middle;}\n" +
+                "        .fof h1 {font-size: 50px; display: inline-block; padding-right: 12px; animation: type .5s alternate infinite;}\n" +
+                "        @keyframes type {from {box-shadow: inset -3px 0px 0px #888;} to {box-shadow: inset -3px 0px 0px transparent;}}\n" +
+                "    </style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "    <div id=\"main\">\n" +
+                "        <div class=\"fof\">\n" +
+                "            <h1>Error "+exception.getErrorCode().getHttpStatus()+"</h1>\n" +
+                "            <h2>"+exception.getErrorCode().getMessage()+"</h2>\n" +
+                "        </div>\n" +
+                "    </div>\n" +
+                "</body>\n" +
+                "</html>\n";
+        return html;
+    }
+}


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
-  JSON 직렬화 및 스웨거 에러 응답 생성

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- TSID 도입 후, 18자리의 긴 정수형 응답을 프론트에서 받을때, 뒤 2자리가 00으로 변경되는 문제를 해결하기 위해 JSON 으로 직렬화할 때 Long 타입을 String 타입으로 변환되도록 설정했습니다. 다음 링크를 참고하면 프론트에서도 위 문제를 해결할 수 있을 것으로 추정됩니다. [참고 링크](https://devpunch.tistory.com/27)
- 스웨거 접속 시 발생하는 에러를 처리하기 위한 커스텀예외 클래스, 에러코드 그리고 예외 발생 시 보여줄 응답을 추가했습니다.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 스웨거 접속 시 보여지는 에러 페이지 샘플 입니다. 
![image](https://github.com/user-attachments/assets/15aa095c-978a-45ef-aa33-4f9d8771cbc0)


---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->