### PR TITLE
fix(possibledatetime): 일정 추가/삭제 쿼리 수정

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.2.3)
+name: Spring Boot Gradle CICD (version 0.2.4)
 
 on:
   push:

--- a/src/main/java/com/swyp3/babpool/domain/possibledatetime/application/PossibleDateTimeServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/possibledatetime/application/PossibleDateTimeServiceImpl.java
@@ -52,14 +52,13 @@ public class PossibleDateTimeServiceImpl implements PossibleDateTimeService{
 
     @Override
     public List<PossibleDateTimeResponse> updatePossibleDateTime(Long userId, PossibleDateTimeUpdateRequest possibleDateTimeUpdateRequest) {
-        
-        // 일정 제거 : possibleDateTimeStatus 가 RESERVED 인 경우는 제외하고 삭제
+        // 일정 제거
         if(!possibleDateTimeUpdateRequest.getPossibleDateTimeDelList().isEmpty()) {
             possibleDateTimeRepository.deletePossibleDateTimeWhereStatusIsNotReserved(userId, possibleDateTimeUpdateRequest.getPossibleDateTimeDelList());
         }
-        // 추가
+        // 일정 추가
         if(!possibleDateTimeUpdateRequest.getPossibleDateTimeAddList().isEmpty()) {
-            possibleDateTimeRepository.savePossibleDateTimeList(possibleDateTimeUpdateRequest.getPossibleDateTimeAddList().stream()
+            possibleDateTimeRepository.savePossibleDateTimeListWhereNotExist(possibleDateTimeUpdateRequest.getPossibleDateTimeAddList().stream()
                     .map(datetime -> PossibleDateTime.builder().possibleDateTimeId(tsidKeyGenerator.generateTsid())
                             .userId(userId)
                             .possibleDateTime(datetime)

--- a/src/main/java/com/swyp3/babpool/domain/possibledatetime/dao/PossibleDateTimeRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/possibledatetime/dao/PossibleDateTimeRepository.java
@@ -40,6 +40,8 @@ public interface PossibleDateTimeRepository {
     // 테스트 코드 작성 완료
     void savePossibleDateTimeList(List<PossibleDateTime> possibleDateTimeList);
 
+    // 테스트 코드 작성 완료
+    void savePossibleDateTimeListWhereNotExist(List<PossibleDateTime> possibleDateTimeList);
 
     @Deprecated
     List<PossibleDateAndTime> findAllPossibleDateAndTimeByProfileIdAndNowDateWithoutAcceptOrDone(Long profileId);

--- a/src/main/resources/mapper/PossibleDateTimeMapper.xml
+++ b/src/main/resources/mapper/PossibleDateTimeMapper.xml
@@ -177,14 +177,17 @@
             <when test="possibleDateTimeDelList != null and possibleDateTimeDelList.size() != 0">
                 DELETE FROM t_possible_datetime
                 WHERE possible_datetime_id IN (
-                    SELECT possible_datetime_id
-                    FROM t_possible_datetime
-                    WHERE user_id = #{userId}
-                    AND possible_datetime_status != 'RESERVED'
-                    AND possible_datetime IN
-                    <foreach collection="possibleDateTimeDelList" item="possibleDateTime" open="(" close=")" separator=",">
-                        #{possibleDateTime}
-                    </foreach>
+                    SELECT temp.possible_datetime_id
+                    FROM (
+                        SELECT possible_datetime_id
+                        FROM t_possible_datetime
+                        WHERE user_id = #{userId}
+                        AND possible_datetime_status != 'RESERVED'
+                        AND possible_datetime IN
+                        <foreach collection="possibleDateTimeDelList" item="possibleDateTime" open="(" close=")" separator=",">
+                            #{possibleDateTime}
+                        </foreach>
+                    ) AS temp
                 )
             </when>
         </choose>

--- a/src/main/resources/mapper/PossibleDateTimeMapper.xml
+++ b/src/main/resources/mapper/PossibleDateTimeMapper.xml
@@ -131,6 +131,26 @@
         </foreach>
     </insert>
 
+    <insert id="savePossibleDateTimeListWhereNotExist">
+        INSERT INTO t_possible_datetime (possible_datetime_id, possible_datetime, possible_datetime_status, user_id)
+        SELECT possibleDateTimeId, possibleDateTime, possibleDateTimeStatus, userId
+        FROM (
+        <foreach collection="possibleDateTimeList" item="possibleDateTime" separator=" UNION ALL ">
+            SELECT CAST(#{possibleDateTime.possibleDateTimeId} AS BIGINT) AS possibleDateTimeId,
+            CAST(#{possibleDateTime.possibleDateTime} AS TIMESTAMP) AS possibleDateTime,
+            CAST(#{possibleDateTime.possibleDateTimeStatus} AS VARCHAR) AS possibleDateTimeStatus,
+            CAST(#{possibleDateTime.userId} AS BIGINT) AS userId
+        </foreach>
+        ) AS new_values
+        WHERE NOT EXISTS (
+        SELECT 1
+        FROM t_possible_datetime
+        WHERE user_id = new_values.userId
+        AND possible_datetime = new_values.possibleDateTime
+        );
+    </insert>
+
+
     <insert id="insertPossibleDate" parameterType="com.swyp3.babpool.domain.possibledatetime.domain.PossibleDateInsertDto"
             useGeneratedKeys="true" keyProperty="possibleDateId">
         INSERT INTO t_possible_datetime(possible_date,profile_id)


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 일정 삭제 쿼리를 수행한 경우 `jdbc.UncategorizedSQLException: Error updating database.` 에러 발생.
- 일정 추가 쿼리를 수행할 때, 이미 존재하는 일정도 중복해 추가되는 문제 발생.


## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 일정 삭제 쿼리
   - MySQL에서 UPDATE & DELETE 를 할 때 자기 테이블의 데이터를 바로 사용하지 못한다. 따라서 서브쿼리를 사용하도록 변경
- 일정 추가 쿼리
   - `WHERE NOT EXISTS` 구문을 사용
- 쿼리트 테스트 메서드 추가

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- [DELETE에서의 서브쿼리 활용](https://velog.io/@khnn/TIL-DELETE%EC%97%90%EC%84%9C%EC%9D%98-%EC%84%9C%EB%B8%8C%EC%BF%BC%EB%A6%AC-%ED%99%9C%EC%9A%A9)
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->