### PR TITLE
hotfix: 일정 상태 변경 mapper 수정

### DIFF
--- a/.github/workflows/github-actions-server.yaml
+++ b/.github/workflows/github-actions-server.yaml
@@ -1,4 +1,4 @@
-name: Spring Boot Gradle CICD (version 0.2.11)
+name: Spring Boot Gradle CICD (version 0.2.12)
 
 on:
   push:

--- a/src/main/java/com/swyp3/babpool/domain/possibledatetime/application/PossibleDateTimeServiceImpl.java
+++ b/src/main/java/com/swyp3/babpool/domain/possibledatetime/application/PossibleDateTimeServiceImpl.java
@@ -43,7 +43,7 @@ public class PossibleDateTimeServiceImpl implements PossibleDateTimeService{
 
     @Override
     public boolean changeStatusAsReserved(Long possibleDateTimeId) {
-        int updatedRows = possibleDateTimeRepository.updatePossibleDateTimeStatus(possibleDateTimeId, PossibleDateTimeStatusType.RESERVED);
+        int updatedRows = possibleDateTimeRepository.updatePossibleDateTimeStatusFromAvailable(possibleDateTimeId, PossibleDateTimeStatusType.RESERVED);
         if (updatedRows != 1){
             throw new PossibleDateTimeException(PossibleDateTimeErrorCode.POSSIBLE_DATETIME_STATUS_UPDATE_FAILED, "밥약 가능한 일정 상태 변경에 실패하였습니다.");
         }

--- a/src/main/java/com/swyp3/babpool/domain/possibledatetime/dao/PossibleDateTimeRepository.java
+++ b/src/main/java/com/swyp3/babpool/domain/possibledatetime/dao/PossibleDateTimeRepository.java
@@ -28,6 +28,8 @@ public interface PossibleDateTimeRepository {
     // 테스트 코드 작성 완료
     int updatePossibleDateTimeStatus(Long possibleDateTimeId, PossibleDateTimeStatusType status);
 
+    int updatePossibleDateTimeStatusFromAvailable(Long possibleDateTimeId, PossibleDateTimeStatusType status);
+
     // 테스트 코드 작성 완료
     List<PossibleDateTime> findAllByUserId(Long userId);
 

--- a/src/main/resources/mapper/PossibleDateTimeMapper.xml
+++ b/src/main/resources/mapper/PossibleDateTimeMapper.xml
@@ -189,11 +189,17 @@
 
     <!-- ==============================  UPDATE  ============================== -->
 
-    <update id="updatePossibleDateTimeStatus">
+    <update id="updatePossibleDateTimeStatusFromAvailable">
         UPDATE t_possible_datetime
         SET possible_datetime_status = #{status}
         WHERE possible_datetime_id = #{possibleDateTimeId}
         AND possible_datetime_status = 'AVAILABLE';
+    </update>
+
+    <update id="updatePossibleDateTimeStatus">
+        UPDATE t_possible_datetime
+        SET possible_datetime_status = #{status}
+        WHERE possible_datetime_id = #{possibleDateTimeId};
     </update>
 
     <!-- ==============================  DELETE  ============================== -->


### PR DESCRIPTION
Resolves #{이슈-번호}
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 기존 `updatePossibleDateTimeStatus` 매퍼는 일정 상태가 `AVAILABLE` 조건이 걸려 있어, `RESERVED` 상태의 일정을 변경하지 못하는 에러가 발생

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- `updatePossibleDateTimeStatusFromAvailable` 를 별도로 생성하여 `AVAILABLE` 조건이 필요할 땐 해당 매퍼를 사용하고, `updatePossibleDateTimeStatus` 매퍼의 경우 일정 상태 조건을 제거함.


### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 

---

### RCA Rule

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 단일 이슈일 경우 <Subject> ‘공백’ (#이슈번호), 복수 이슈일 경우 쉼표로 구분하여 여러 이슈번호를 적는다.
-->